### PR TITLE
fix(hud): update statusLine path on every version change

### DIFF
--- a/scripts/setup-hud.mjs
+++ b/scripts/setup-hud.mjs
@@ -51,10 +51,10 @@ async function main() {
       settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
     }
 
-    // Check if statusLine is already set to crew HUD
+    // Check if statusLine is already set to the *current* plugin path
     const currentCommand = settings.statusLine?.command || '';
-    if (currentCommand.includes('crew') && currentCommand.includes('hud/index.mjs')) {
-      // Already configured
+    if (currentCommand === hudCommand) {
+      // Already configured with this exact version
       console.log(JSON.stringify({ continue: true }));
       return;
     }


### PR DESCRIPTION
## Summary
- `setup-hud.mjs`의 statusLine 경로 비교를 `includes()` → exact match로 변경
- 플러그인 업그레이드 후 캐시된 이전 경로가 그대로 남아 HUD가 갱신되지 않던 문제 수정

## Test plan
- [ ] 플러그인 버전 업그레이드 후 새 세션 시작 시 statusLine 경로가 갱신되는지 확인
- [ ] 이미 올바른 경로일 때 불필요한 재설정이 일어나지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)