### PR TITLE
fix: apply worktree path resolution to setup-hud hook

### DIFF
--- a/scripts/setup-hud.mjs
+++ b/scripts/setup-hud.mjs
@@ -9,7 +9,7 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 
 // ---------------------------------------------------------------------------
@@ -50,8 +50,13 @@ async function main() {
     try { cwd = JSON.parse(raw).cwd || cwd; } catch { /* ignore */ }
   }
 
-  // Use git toplevel as the reliable project root
-  const projectRoot = gitExec('git rev-parse --show-toplevel', cwd) || cwd;
+  // In worktrees, --show-toplevel returns the worktree path, not the main repo.
+  // Use --git-common-dir to resolve back to the main repo path.
+  const topLevel = gitExec('git rev-parse --show-toplevel', cwd) || cwd;
+  const commonDir = gitExec('git rev-parse --git-common-dir', cwd);
+  const projectRoot = (commonDir && commonDir !== '.git' && !commonDir.startsWith('.'))
+    ? dirname(commonDir)  // worktree: commonDir is /path/to/main-repo/.git
+    : topLevel;
 
   const hudCommand = `node "${pluginRoot}/hud/index.mjs"`;
   const localSettingsPath = join(projectRoot, '.claude', 'settings.local.json');


### PR DESCRIPTION
## Summary
- `setup-hud.mjs`에서 `git rev-parse --show-toplevel` 대신 `--git-common-dir` 기반 경로 해석 적용
- 워크트리 안에서 세션 시작 시 `settings.local.json`이 메인 레포의 `.claude/`에 올바르게 기록됨
- `hud/index.mjs`에 이미 적용된 동일한 패턴 (commit 6a8083f)

## Context
플러그인 업데이트 후 워크트리 내에서 세션을 시작하면, setup-hud 훅이 워크트리의 `.claude/settings.local.json`에 새 버전 경로를 기록하고 메인 레포의 것은 이전 버전 경로가 그대로 남아 HUD가 표시되지 않는 문제.

## Test plan
- [ ] 워크트리 안에서 세션 시작 후 메인 레포의 `.claude/settings.local.json` statusLine 경로 확인
- [ ] 메인 레포에서 세션 시작 후 동일 확인 (기존 동작 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)