### PR TITLE
fix: support user-level install in HUD install detection

### DIFF
--- a/hud/index.mjs
+++ b/hud/index.mjs
@@ -47,13 +47,16 @@ async function readStdin(timeoutMs = 1000) {
 // ---------------------------------------------------------------------------
 // Project installation info from installed_plugins.json
 // ---------------------------------------------------------------------------
-function getProjectInstallInfo(projectRoot) {
+function getInstallInfo(projectRoot) {
   try {
     const pluginsJsonPath = join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
     if (!existsSync(pluginsJsonPath)) return null;
     const data = JSON.parse(readFileSync(pluginsJsonPath, 'utf-8'));
     const crewEntries = data.plugins?.['claude-crew@claude-crew'] || [];
-    return crewEntries.find(e => e.projectPath === projectRoot) || null;
+    // Prefer project-level install, fall back to user-level install
+    return crewEntries.find(e => e.projectPath === projectRoot)
+      || crewEntries.find(e => e.scope === 'user')
+      || null;
   } catch { return null; }
 }
 
@@ -591,8 +594,8 @@ async function main() {
     ? dirname(commonDir)  // worktree: commonDir is /path/to/main-repo/.git
     : topLevel;
 
-  // Only show HUD if claude-crew is installed in this project
-  const installInfo = getProjectInstallInfo(projectRoot);
+  // Only show HUD if claude-crew is installed (project-level or user-level)
+  const installInfo = getInstallInfo(projectRoot);
   if (!installInfo) return;
 
   const version = getVersion(installInfo);


### PR DESCRIPTION
## Summary
- `getProjectInstallInfo()`가 `projectPath` 매칭만 수행하여 user-level 설치(`scope: "user"`) 시 HUD가 표시되지 않던 문제 수정
- project-level 매칭 우선, user-level fallback으로 변경

## Test plan
- [ ] user-level로 claude-crew 설치 후 HUD가 정상 표시되는지 확인
- [ ] project-level 설치 시에도 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)