### PR TITLE
fix(hud): show agents in worktree by falling back to original transcript

### DIFF
--- a/hud/index.mjs
+++ b/hud/index.mjs
@@ -664,17 +664,20 @@ async function main() {
 
   const transcript = parseTranscript(stdin.transcript_path);
 
-  // In worktrees, merge todos from the original project transcript.
+  // In worktrees, merge data from the original project transcript.
   // The worktree transcript only has events after EnterWorktree, so todos
-  // created before are missing. The original transcript has the full history.
-  // If the worktree transcript also has todos (created after worktree entry),
-  // use the worktree's todos since they are more up-to-date for that session.
-  if (transcript.todos.length === 0) {
+  // and agents created before are missing. The original transcript has the
+  // full history. If the worktree transcript already has its own data
+  // (created after worktree entry), prefer the worktree's version.
+  if (transcript.todos.length === 0 || transcript.agents.length === 0) {
     const originalPath = resolveOriginalTranscriptPath(stdin.transcript_path, cwd);
     if (originalPath) {
       const originalTranscript = parseTranscript(originalPath);
-      if (originalTranscript.todos.length > 0) {
+      if (transcript.todos.length === 0 && originalTranscript.todos.length > 0) {
         transcript.todos = originalTranscript.todos;
+      }
+      if (transcript.agents.length === 0 && originalTranscript.agents.length > 0) {
+        transcript.agents = originalTranscript.agents;
       }
     }
   }


### PR DESCRIPTION
## Summary
- `EnterWorktree` 후 `stdin.transcript_path`가 워크트리 프로젝트 디렉토리로 변경되지만, Agent 이벤트는 여전히 원본(메인 레포) transcript에 기록됨
- 기존 todo fallback (182b958)과 동일한 근본 원인 — agents에도 같은 패턴 적용
- `resolveOriginalTranscriptPath` 한 번만 호출하여 todos + agents를 함께 머지

## Test plan
- [ ] 메인 레포에서 `EnterWorktree` 후 Agent spawn → HUD에 agent 표시 확인
- [ ] 워크트리 없는 일반 세션에서 agent 표시가 기존과 동일한지 확인
- [ ] todo fallback이 여전히 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)