### PR TITLE
refactor: claude 모델 라벨에서 버전 숫자 제거

### DIFF
--- a/data/provider-catalog.json
+++ b/data/provider-catalog.json
@@ -1,9 +1,9 @@
 {
   "claude": {
     "models": [
-      { "id": "opus", "label": "Opus 4.6 — 최고 품질, 복잡한 구현", "default_for": ["dev", "code-reviewer"] },
-      { "id": "sonnet", "label": "Sonnet 4.6 — 빠르고 저렴, Opus급 성능", "default_for": ["qa"] },
-      { "id": "haiku", "label": "Haiku 4.5 — 최저 비용, 단순 태스크", "default_for": [] }
+      { "id": "opus", "label": "Opus — 최고 품질, 복잡한 구현", "default_for": ["dev", "code-reviewer"] },
+      { "id": "sonnet", "label": "Sonnet — 빠르고 저렴, Opus급 성능", "default_for": ["qa"] },
+      { "id": "haiku", "label": "Haiku — 최저 비용, 단순 태스크", "default_for": [] }
     ]
   },
   "codex": {

--- a/skills/crew-setup/SKILL.md
+++ b/skills/crew-setup/SKILL.md
@@ -192,9 +192,9 @@ Provider:
 claude 선택 시:
 ```
 Model:
-  [1] Opus 4.6 — 최고 품질, 복잡한 구현 (추천)
-  [2] Sonnet 4.6 — 빠르고 저렴, Opus급 성능
-  [3] Haiku 4.5 — 최저 비용, 단순 태스크
+  [1] Opus — 최고 품질, 복잡한 구현 (추천)
+  [2] Sonnet — 빠르고 저렴, Opus급 성능
+  [3] Haiku — 최저 비용, 단순 태스크
 ```
 
 codex 선택 시:


### PR DESCRIPTION
## Summary
- `data/provider-catalog.json`과 `skills/crew-setup/SKILL.md`의 claude 티어 라벨에서 `4.6`/`4.5` 등 버전 숫자 제거 (`Opus — ...`, `Sonnet — ...`, `Haiku — ...`)
- 내부 식별자는 어차피 `opus`/`sonnet`/`haiku` 별칭이라 Claude Code가 자동으로 최신 모델로 resolve함 → 라벨의 버전 숫자는 cosmetic, 릴리스마다 수동 갱신해야 하는 유지보수 부담만 발생
- HUD(`hud/index.mjs:162`)는 이미 statusline stdin의 `model.display_name`을 실측해 "Opus 4.7 (1M context)" 형태로 정확히 노출하므로 버전 정보 손실 없음
- codex는 `id: "gpt-5.4"`처럼 버전이 모델 식별자의 일부이므로 현상 유지

## Motivation
oh-my-claudecode와 동일한 패턴 — 정적 문서/라벨은 티어 이름만, 실제 버전은 런타임(HUD)에서만 표기.

## Test plan
- [ ] `crew-setup` 스킬 실행 시 Model 선택 메뉴가 `Opus — 최고 품질...`처럼 버전 없이 노출되는지 확인
- [ ] HUD가 현재 active 모델의 display_name을 여전히 정확히 표시하는지 확인 ("Opus 4.7 (1M context)" 등)
- [ ] `data/provider-catalog.json` JSON 파싱 유효성