### PR TITLE
fix: codex exec stdin hang + gpt-5.5 모델 추가

### DIFF
--- a/data/provider-catalog.json
+++ b/data/provider-catalog.json
@@ -8,12 +8,14 @@
   },
   "codex": {
     "models": [
-      { "id": "gpt-5.4", "reasoning": "xhigh", "label": "GPT-5.4 xhigh (추천) — 최고 성능, 토큰 多", "default_for": ["dev", "code-reviewer"] },
-      { "id": "gpt-5.4", "reasoning": "high", "label": "GPT-5.4 high — 고성능, 균형잡힌 비용", "default_for": [] },
-      { "id": "gpt-5.4", "reasoning": "medium", "label": "GPT-5.4 medium — 빠르고 저렴", "default_for": [] },
+      { "id": "gpt-5.5", "reasoning": "high", "label": "GPT-5.5 high (추천) — 최고 성능, 균형잡힌 비용", "default_for": ["dev", "code-reviewer"] },
+      { "id": "gpt-5.5", "reasoning": "xhigh", "label": "GPT-5.5 xhigh — 최대 추론, 토큰 多", "default_for": [] },
+      { "id": "gpt-5.5", "reasoning": "medium", "label": "GPT-5.5 medium — 빠르고 저렴", "default_for": [] },
+      { "id": "gpt-5.4", "reasoning": "high", "label": "GPT-5.4 high — 이전 세대, 안정적", "default_for": [] },
+      { "id": "gpt-5.4", "reasoning": "xhigh", "label": "GPT-5.4 xhigh — 이전 세대, 최대 추론", "default_for": [] },
       { "id": "o3", "reasoning": "high", "label": "o3 high — 추론 특화", "default_for": [] },
       { "id": "o3", "reasoning": "medium", "label": "o3 medium — 추론 특화, 저비용", "default_for": [] },
-      { "id": "gpt-5.4-mini", "reasoning": null, "label": "GPT-5.4 Mini — 최저 비용", "default_for": ["qa"] }
+      { "id": "gpt-5.5-mini", "reasoning": null, "label": "GPT-5.5 Mini — 최저 비용", "default_for": ["qa"] }
     ]
   },
   "agent_defaults": {

--- a/skills/crew-dev/SKILL.md
+++ b/skills/crew-dev/SKILL.md
@@ -29,7 +29,7 @@ description: contract.md를 입력으로 받아 Dev + CodeReviewer + QA 파이�
 
 **해석된 설정 예시:**
 ```json
-{ "provider": "codex", "model": "gpt-5.4", "reasoning": "xhigh" }
+{ "provider": "codex", "model": "gpt-5.5", "reasoning": "high" }
 { "provider": "claude", "model": "opus" }
 ```
 

--- a/skills/crew-dev/SKILL.md
+++ b/skills/crew-dev/SKILL.md
@@ -43,7 +43,7 @@ Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")
 
 **codex provider:**
 ```
-Bash("codex exec --model {model} -c model_reasoning_effort=\"{reasoning}\" --dangerously-bypass-approvals-and-sandbox \"{prompt}\"")
+Bash("codex exec --model {model} -c model_reasoning_effort=\"{reasoning}\" --dangerously-bypass-approvals-and-sandbox \"{prompt}\" < /dev/null")
 ```
 - 프롬프트가 길면 임시 파일에 저장 후 `cat`으로 전달한다.
 - Codex는 CWD 기준으로 작업하므로 워크트리 안에서 실행한다.
@@ -324,7 +324,7 @@ codex exec --model {model} -c model_reasoning_effort="{reasoning}" --dangerously
 - US-{k} 구현 내용 1줄 요약
 - 자체 검증 결과 (각 항목별 PASS/FAIL + 명령어 + 출력)
 PROMPT
-)"
+)" < /dev/null
 ```
 
 Codex stdout을 캡처하여 dev-log.md의 US-{k} 섹션으로 추가한다.


### PR DESCRIPTION
## Summary
- codex exec를 background에서 실행할 때 빈 stdin pipe를 추가 입력으로 인식하여 무한 대기하는 문제를 `< /dev/null`로 수정
- codex 기본 모델을 gpt-5.5 high로 변경, gpt-5.5 모델 3종 + mini 추가

## Test plan
- [ ] codex provider로 crew-dev 실행 시 stdin hang 없이 정상 동작 확인
- [ ] crew-setup에서 gpt-5.5 모델 목록 정상 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)