### PR TITLE
fix: CodeReviewer가 .crew/ 메타 파일을 false positive로 FAIL 지적하는 버그

### DIFF
--- a/skills/crew-dev/SKILL.md
+++ b/skills/crew-dev/SKILL.md
@@ -99,7 +99,7 @@ Bash("codex exec --model {model} -c model_reasoning_effort=\"{reasoning}\" --dan
 | 에이전트 | subagent_type | 볼 수 있는 것 | 차단 | 차단 근거 |
 |----------|--------------|-------------|------|----------|
 | **Dev** | dev | plan.md, contract.md | brief.md, spec.md, analysis.md | 의도 추측 방지, plan+contract에 필요 정보 포함 |
-| **CodeReviewer** | code-reviewer | git diff(직접 실행), 가드레일(인라인) | contract.md, plan.md, brief.md, spec.md, dev-log.md | 수용 기준 체리피킹 방지 (.crew/는 .gitignore 대상이므로 diff에 노출되지 않음) |
+| **CodeReviewer** | code-reviewer | git diff(직접 실행, `':!.crew/'` exclude), 가드레일(인라인) | contract.md, plan.md, brief.md, spec.md, dev-log.md | 수용 기준 체리피킹 방지 (.crew/는 git diff 호출 시 pathspec `':!.crew/'`로 명시적 exclude하여 메타 파일 노출 방지) |
 | **QA** | qa | plan.md | contract.md, brief.md, spec.md | 검증 편향 방지 |
 
 **중요**: 모든 에이전트 호출 시 반드시 `subagent_type` 파라미터를 지정해야 한다. `subagent_type`이 없으면 PreToolUse hook이 호출을 차단한다. `model` 파라미터는 생략 가능 — hook이 에이전트 정의에서 자동 주입한다.
@@ -415,7 +415,7 @@ CodeReviewer와 QA를 **동시에** 호출한다. US-k의 변경분만 검증한
 당신은 CodeReviewer 에이전트다. 코드 변경 사항의 품질을 판단한다.
 
 ## 입력
-`git diff HEAD`를 직접 실행하여 마지막 커밋 이후 변경 사항을 확인하라.
+`git diff HEAD -- ':!.crew/'`를 직접 실행하여 마지막 커밋 이후의 **코드 산출물 변경 사항만** 확인하라. (`.crew/` 디렉토리는 crew-dev 파이프라인의 메타 파일로, 본 리뷰 범위가 아니다.)
 contract.md, plan.md, brief.md, spec.md, dev-log.md는 읽지 않는다.
 코드만 보고 판단한다.
 
@@ -591,7 +591,7 @@ CodeReviewer와 QA를 **동시에** 호출한다.
 당신은 CodeReviewer 에이전트다. 전체 코드 변경 사항의 품질을 판단한다.
 
 ## 입력
-`git diff main...HEAD`를 직접 실행하여 전체 변경 사항을 확인하라.
+`git diff main...HEAD -- ':!.crew/'`를 직접 실행하여 전체 **코드 산출물 변경 사항만** 확인하라. (`.crew/` 디렉토리는 crew-dev 파이프라인의 메타 파일로, 본 리뷰 범위가 아니다.)
 contract.md, plan.md, brief.md, spec.md, dev-log.md는 읽지 않는다.
 코드만 보고 판단한다.
 


### PR DESCRIPTION
## Summary
- crew-dev Phase 2/3 CodeReviewer가 dev 에이전트의 누적 산출물인 `.crew/plans/{task-id}/dev-log.md` 변경분 때문에 \"US-{k} 범위 외 변경\"으로 critical FAIL을 내는 버그 수정
- `git diff HEAD` / `git diff main...HEAD` 호출에 pathspec `':!.crew/'`를 추가해 메타 파일을 명시적으로 제외
- 정보 차단 정책 표의 footnote(\".crew/는 .gitignore 대상\")가 crew-setup이 만드는 실제 .gitignore 패턴(`.crew/config.json`, `.crew/plans/**/.*`만 무시)과 어긋나 있던 부분도 정정

## Root cause
매뉴얼이 \".crew/는 .gitignore 대상이라 diff에 노출되지 않음\"이라고 가정했지만, 실제로 dev-log.md / plan.md / contract.md / qa-report.md 등은 git에 커밋되어 `git diff`에 그대로 노출됨. CodeReviewer 프롬프트는 가드레일에 따라 범위 외 파일을 critical로 지적하므로 dev retry로는 절대 빠져나올 수 없는 무한 루프 발생.

## Discovered in
KWatch 프로젝트 seo-branding 태스크 US-2(정적 자산 + Manifest) 검증 단계. 코드 4파일은 모두 OK였으나 dev-log.md 한 파일 때문에 전체 FAIL.

## Test plan
- [ ] 임의 task-id로 crew-interview → crew-plan → crew-dev 흐름 실행
- [ ] dev 에이전트가 dev-log.md를 누적 업데이트하는 동작은 그대로 유지되는지 확인
- [ ] CodeReviewer가 dev-log.md 변경을 무시하고 코드 산출물만으로 판정하는지 확인
- [ ] 워크트리에서 \`git diff HEAD -- ':!.crew/'\` / \`git diff main...HEAD -- ':!.crew/'\`가 코드 산출물만 출력하는지 직접 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)