### PR TITLE
Embed Codex app-server runtime

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,7 @@
     "solo-developer"
   ],
   "agents": [
+    "./agents/pm.md",
     "./agents/planner.md",
     "./agents/dev.md",
     "./agents/qa.md",

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ Claude Code에서:
 | **CodeReviewer** | 코드 리뷰 | dev |
 | **QA** | 실행 검증 | dev |
 
+## 모델 설정
+
+`/crew-setup`에서 에이전트별 provider/model을 설정합니다. 설정하지 않은 에이전트는 `data/provider-catalog.json`의 `agent_defaults`를 따릅니다.
+
+기본값은 기존 에이전트 frontmatter 모델을 따르되, Dev와 CodeReviewer는 Codex `gpt-5.5 medium`을 사용합니다. Claude 모델은 `opus`, `sonnet`, `haiku` latest alias와 `claude-opus-4-7` 같은 버전 고정 ID를 모두 선택할 수 있습니다.
+
+Claude provider는 Claude Code `Agent`로 실행하고, Codex provider는 플러그인에 내장된 `scripts/crew-codex-companion.mjs` app-server runtime으로 실행합니다. 에이전트가 유저 질문이나 다른 에이전트 호출이 필요하면 직접 처리하지 않고 오케스트레이터가 이어받아 실행합니다.
+
+Provider와 무관하게 에이전트 결과는 `complete`, `blocked_on_user`, `needs_agent`, `needs_tool`, `failed` 상태 중 하나로 해석합니다. Claude Code 전용 도구가 필요한 경우에도 Codex provider는 요청 상태를 반환하고, 실제 도구 실행은 오케스트레이터가 담당합니다.
+
 ## 상태 파일
 
 프로젝트 로컬 `.crew/` 디렉토리에 마크다운 파일로 상태를 관리합니다 (git tracked). 플러그인 업데이트 시에도 학습 내용과 상태는 보존됩니다.
@@ -111,4 +121,4 @@ Claude Code에서:
 
 ## License
 
-MIT
+MIT. This project also includes Apache-2.0 third-party components under `scripts/crew-codex/`; see `THIRD_PARTY_NOTICES.md`.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,14 @@
+# Third-Party Notices
+
+claude-crew includes vendored components derived from the OpenAI Codex plugin for Claude Code.
+
+## OpenAI Codex Plugin for Claude Code
+
+- Source: `@openai/codex-plugin-cc`
+- License: Apache License 2.0
+- Vendored path: `scripts/crew-codex/` and `scripts/crew-codex-companion.mjs`
+
+The vendored runtime has been modified for claude-crew integration, including path changes, command-surface reduction, state directory naming, and provider orchestration usage.
+
+The Apache License 2.0 text is included at `scripts/crew-codex/LICENSE`.
+The original NOTICE text is included at `scripts/crew-codex/NOTICE`.

--- a/data/provider-catalog.json
+++ b/data/provider-catalog.json
@@ -1,26 +1,37 @@
 {
   "claude": {
     "models": [
-      { "id": "opus", "label": "Opus — 최고 품질, 복잡한 구현", "default_for": ["dev", "code-reviewer"] },
-      { "id": "sonnet", "label": "Sonnet — 빠르고 저렴, Opus급 성능", "default_for": ["qa"] },
-      { "id": "haiku", "label": "Haiku — 최저 비용, 단순 태스크", "default_for": [] }
+      { "id": "opus", "status": "active" },
+      { "id": "claude-opus-4-7", "status": "active" },
+      { "id": "claude-opus-4-6", "status": "active" },
+      { "id": "sonnet", "status": "active" },
+      { "id": "claude-sonnet-4-6", "status": "active" },
+      { "id": "haiku", "status": "active" },
+      { "id": "claude-haiku-4-5", "status": "active" }
     ]
   },
   "codex": {
     "models": [
-      { "id": "gpt-5.5", "reasoning": "high", "label": "GPT-5.5 high (추천) — 최고 성능, 균형잡힌 비용", "default_for": ["dev", "code-reviewer"] },
-      { "id": "gpt-5.5", "reasoning": "xhigh", "label": "GPT-5.5 xhigh — 최대 추론, 토큰 多", "default_for": [] },
-      { "id": "gpt-5.5", "reasoning": "medium", "label": "GPT-5.5 medium — 빠르고 저렴", "default_for": [] },
-      { "id": "gpt-5.4", "reasoning": "high", "label": "GPT-5.4 high — 이전 세대, 안정적", "default_for": [] },
-      { "id": "gpt-5.4", "reasoning": "xhigh", "label": "GPT-5.4 xhigh — 이전 세대, 최대 추론", "default_for": [] },
-      { "id": "o3", "reasoning": "high", "label": "o3 high — 추론 특화", "default_for": [] },
-      { "id": "o3", "reasoning": "medium", "label": "o3 medium — 추론 특화, 저비용", "default_for": [] },
-      { "id": "gpt-5.5-mini", "reasoning": null, "label": "GPT-5.5 Mini — 최저 비용", "default_for": ["qa"] }
+      { "id": "gpt-5.5", "reasoning": "xhigh", "status": "active" },
+      { "id": "gpt-5.5", "reasoning": "high", "status": "active" },
+      { "id": "gpt-5.5", "reasoning": "medium", "status": "active" },
+      { "id": "gpt-5.4", "reasoning": "xhigh", "status": "active" },
+      { "id": "gpt-5.4", "reasoning": "high", "status": "active" },
+      { "id": "gpt-5.4", "reasoning": "medium", "status": "active" },
+      { "id": "o3", "reasoning": "high", "status": "active" },
+      { "id": "o3", "reasoning": "medium", "status": "active" },
+      { "id": "gpt-5.5-mini", "reasoning": "medium", "status": "active" }
     ]
   },
   "agent_defaults": {
-    "dev": { "provider": "claude", "model": "opus" },
-    "code-reviewer": { "provider": "claude", "model": "opus" },
-    "qa": { "provider": "claude", "model": "sonnet" }
+    "pm": { "provider": "claude", "model": "opus" },
+    "techlead": { "provider": "claude", "model": "opus" },
+    "planner": { "provider": "claude", "model": "opus" },
+    "plan-evaluator": { "provider": "claude", "model": "sonnet" },
+    "explorer": { "provider": "claude", "model": "haiku" },
+    "researcher": { "provider": "claude", "model": "sonnet" },
+    "qa": { "provider": "claude", "model": "sonnet" },
+    "dev": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" },
+    "code-reviewer": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" }
   }
 }

--- a/data/provider-catalog.json
+++ b/data/provider-catalog.json
@@ -33,5 +33,16 @@
     "qa": { "provider": "claude", "model": "sonnet" },
     "dev": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" },
     "code-reviewer": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" }
+  },
+  "agent_runtime": {
+    "pm": { "codex_sandbox": "read-only" },
+    "techlead": { "codex_sandbox": "read-only" },
+    "planner": { "codex_sandbox": "read-only" },
+    "plan-evaluator": { "codex_sandbox": "read-only" },
+    "explorer": { "codex_sandbox": "read-only" },
+    "researcher": { "codex_sandbox": "read-only" },
+    "qa": { "codex_sandbox": "read-only" },
+    "dev": { "codex_sandbox": "workspace-write" },
+    "code-reviewer": { "codex_sandbox": "read-only" }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hooks/",
     "hud/",
     "scripts/",
+    "THIRD_PARTY_NOTICES.md",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -1,0 +1,1015 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { parseArgs, splitRawArgumentString } from "./crew-codex/lib/args.mjs";
+import {
+    buildPersistentTaskThreadName,
+    DEFAULT_CONTINUE_PROMPT,
+    findLatestTaskThread,
+    getCodexAuthStatus,
+    getCodexAvailability,
+    getSessionRuntimeStatus,
+    interruptAppServerTurn,
+    parseStructuredOutput,
+    readOutputSchema,
+    runAppServerReview,
+    runAppServerTurn
+  } from "./crew-codex/lib/codex.mjs";
+import { readStdinIfPiped } from "./crew-codex/lib/fs.mjs";
+import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./crew-codex/lib/git.mjs";
+import { binaryAvailable, terminateProcessTree } from "./crew-codex/lib/process.mjs";
+import { loadPromptTemplate, interpolateTemplate } from "./crew-codex/lib/prompts.mjs";
+import {
+  generateJobId,
+  getConfig,
+  listJobs,
+  setConfig,
+  upsertJob,
+  writeJobFile
+} from "./crew-codex/lib/state.mjs";
+import {
+  buildSingleJobSnapshot,
+  buildStatusSnapshot,
+  readStoredJob,
+  resolveCancelableJob,
+  resolveResultJob,
+  sortJobsNewestFirst
+} from "./crew-codex/lib/job-control.mjs";
+import {
+  appendLogLine,
+  createJobLogFile,
+  createJobProgressUpdater,
+  createJobRecord,
+  createProgressReporter,
+  nowIso,
+  runTrackedJob,
+  SESSION_ID_ENV
+} from "./crew-codex/lib/tracked-jobs.mjs";
+import { resolveWorkspaceRoot } from "./crew-codex/lib/workspace.mjs";
+import {
+  renderNativeReviewResult,
+  renderReviewResult,
+  renderStoredJobResult,
+  renderCancelReport,
+  renderJobStatusReport,
+  renderSetupReport,
+  renderStatusReport,
+  renderTaskResult
+} from "./crew-codex/lib/render.mjs";
+
+const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
+const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
+const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
+const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
+const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
+
+function printUsage() {
+  console.log(
+    [
+      "Usage:",
+      "  node scripts/crew-codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/crew-codex-companion.mjs status [job-id] [--all] [--json]",
+      "  node scripts/crew-codex-companion.mjs result [job-id] [--json]",
+      "  node scripts/crew-codex-companion.mjs cancel [job-id] [--json]"
+    ].join("\n")
+  );
+}
+
+function outputResult(value, asJson) {
+  if (asJson) {
+    console.log(JSON.stringify(value, null, 2));
+  } else {
+    process.stdout.write(value);
+  }
+}
+
+function outputCommandResult(payload, rendered, asJson) {
+  outputResult(asJson ? payload : rendered, asJson);
+}
+
+function normalizeRequestedModel(model) {
+  if (model == null) {
+    return null;
+  }
+  const normalized = String(model).trim();
+  if (!normalized) {
+    return null;
+  }
+  return MODEL_ALIASES.get(normalized.toLowerCase()) ?? normalized;
+}
+
+function normalizeReasoningEffort(effort) {
+  if (effort == null) {
+    return null;
+  }
+  const normalized = String(effort).trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (!VALID_REASONING_EFFORTS.has(normalized)) {
+    throw new Error(
+      `Unsupported reasoning effort "${effort}". Use one of: none, minimal, low, medium, high, xhigh.`
+    );
+  }
+  return normalized;
+}
+
+function normalizeArgv(argv) {
+  if (argv.length === 1) {
+    const [raw] = argv;
+    if (!raw || !raw.trim()) {
+      return [];
+    }
+    return splitRawArgumentString(raw);
+  }
+  return argv;
+}
+
+function parseCommandInput(argv, config = {}) {
+  return parseArgs(normalizeArgv(argv), {
+    ...config,
+    aliasMap: {
+      C: "cwd",
+      ...(config.aliasMap ?? {})
+    }
+  });
+}
+
+function resolveCommandCwd(options = {}) {
+  return options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+}
+
+function resolveCommandWorkspace(options = {}) {
+  return resolveWorkspaceRoot(resolveCommandCwd(options));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function shorten(text, limit = 96) {
+  const normalized = String(text ?? "").trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  return `${normalized.slice(0, limit - 3)}...`;
+}
+
+function firstMeaningfulLine(text, fallback) {
+  const line = String(text ?? "")
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .find(Boolean);
+  return line ?? fallback;
+}
+
+async function buildSetupReport(cwd, actionsTaken = []) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const nodeStatus = binaryAvailable("node", ["--version"], { cwd });
+  const npmStatus = binaryAvailable("npm", ["--version"], { cwd });
+  const codexStatus = getCodexAvailability(cwd);
+  const authStatus = await getCodexAuthStatus(cwd);
+  const config = getConfig(workspaceRoot);
+
+  const nextSteps = [];
+  if (!codexStatus.available) {
+    nextSteps.push("Install Codex with `npm install -g @openai/codex`.");
+  }
+  if (codexStatus.available && !authStatus.loggedIn && authStatus.requiresOpenaiAuth) {
+    nextSteps.push("Run `!codex login`.");
+    nextSteps.push("If browser login is blocked, retry with `!codex login --device-auth` or `!codex login --with-api-key`.");
+  }
+  if (!config.stopReviewGate) {
+    nextSteps.push("Optional: run `/crew-setup --enable-review-gate` to require a fresh review before stop.");
+  }
+
+  return {
+    ready: nodeStatus.available && codexStatus.available && authStatus.loggedIn,
+    node: nodeStatus,
+    npm: npmStatus,
+    codex: codexStatus,
+    auth: authStatus,
+    sessionRuntime: getSessionRuntimeStatus(process.env, workspaceRoot),
+    reviewGateEnabled: Boolean(config.stopReviewGate),
+    actionsTaken,
+    nextSteps
+  };
+}
+
+async function handleSetup(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["cwd"],
+    booleanOptions: ["json", "enable-review-gate", "disable-review-gate"]
+  });
+
+  if (options["enable-review-gate"] && options["disable-review-gate"]) {
+    throw new Error("Choose either --enable-review-gate or --disable-review-gate.");
+  }
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  const actionsTaken = [];
+
+  if (options["enable-review-gate"]) {
+    setConfig(workspaceRoot, "stopReviewGate", true);
+    actionsTaken.push(`Enabled the stop-time review gate for ${workspaceRoot}.`);
+  } else if (options["disable-review-gate"]) {
+    setConfig(workspaceRoot, "stopReviewGate", false);
+    actionsTaken.push(`Disabled the stop-time review gate for ${workspaceRoot}.`);
+  }
+
+  const finalReport = await buildSetupReport(cwd, actionsTaken);
+  outputResult(options.json ? finalReport : renderSetupReport(finalReport), options.json);
+}
+
+function buildAdversarialReviewPrompt(context, focusText) {
+  const template = loadPromptTemplate(ROOT_DIR, "adversarial-review");
+  return interpolateTemplate(template, {
+    REVIEW_KIND: "Adversarial Review",
+    TARGET_LABEL: context.target.label,
+    USER_FOCUS: focusText || "No extra focus provided.",
+    REVIEW_COLLECTION_GUIDANCE: context.collectionGuidance,
+    REVIEW_INPUT: context.content
+  });
+}
+
+function ensureCodexAvailable(cwd) {
+  const availability = getCodexAvailability(cwd);
+  if (!availability.available) {
+    throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/crew-setup`.");
+  }
+}
+
+function buildNativeReviewTarget(target) {
+  if (target.mode === "working-tree") {
+    return { type: "uncommittedChanges" };
+  }
+
+  if (target.mode === "branch") {
+    return { type: "baseBranch", branch: target.baseRef };
+  }
+
+  return null;
+}
+
+function validateNativeReviewRequest(target, focusText) {
+  if (focusText.trim()) {
+    throw new Error(
+      `\`crew review\` now maps directly to the built-in reviewer and does not support custom focus text. Retry with \`crew adversarial review ${focusText.trim()}\` for focused review instructions.`
+    );
+  }
+
+  const nativeTarget = buildNativeReviewTarget(target);
+  if (!nativeTarget) {
+    throw new Error("This `crew review` target is not supported by the built-in reviewer. Retry with `crew adversarial review` for custom targeting.");
+  }
+
+  return nativeTarget;
+}
+
+function renderStatusPayload(report, asJson) {
+  return asJson ? report : renderStatusReport(report);
+}
+
+function isActiveJobStatus(status) {
+  return status === "queued" || status === "running";
+}
+
+function getCurrentClaudeSessionId() {
+  return process.env[SESSION_ID_ENV] ?? null;
+}
+
+function filterJobsForCurrentClaudeSession(jobs) {
+  const sessionId = getCurrentClaudeSessionId();
+  if (!sessionId) {
+    return jobs;
+  }
+  return jobs.filter((job) => job.sessionId === sessionId);
+}
+
+function findLatestResumableTaskJob(jobs) {
+  return (
+    jobs.find(
+      (job) =>
+        job.jobClass === "task" &&
+        job.threadId &&
+        job.status !== "queued" &&
+        job.status !== "running"
+    ) ?? null
+  );
+}
+
+async function waitForSingleJobSnapshot(cwd, reference, options = {}) {
+  const timeoutMs = Math.max(0, Number(options.timeoutMs) || DEFAULT_STATUS_WAIT_TIMEOUT_MS);
+  const pollIntervalMs = Math.max(100, Number(options.pollIntervalMs) || DEFAULT_STATUS_POLL_INTERVAL_MS);
+  const deadline = Date.now() + timeoutMs;
+  let snapshot = buildSingleJobSnapshot(cwd, reference);
+
+  while (isActiveJobStatus(snapshot.job.status) && Date.now() < deadline) {
+    await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
+    snapshot = buildSingleJobSnapshot(cwd, reference);
+  }
+
+  return {
+    ...snapshot,
+    waitTimedOut: isActiveJobStatus(snapshot.job.status),
+    timeoutMs
+  };
+}
+
+async function resolveLatestTrackedTaskThread(cwd, options = {}) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const sessionId = getCurrentClaudeSessionId();
+  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot)).filter((job) => job.id !== options.excludeJobId);
+  const visibleJobs = filterJobsForCurrentClaudeSession(jobs);
+  const activeTask = visibleJobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
+  if (activeTask) {
+    throw new Error(`Task ${activeTask.id} is still running. Use crew-codex status before continuing it.`);
+  }
+
+  const trackedTask = findLatestResumableTaskJob(visibleJobs);
+  if (trackedTask) {
+    return { id: trackedTask.threadId };
+  }
+
+  if (sessionId) {
+    return null;
+  }
+
+  return findLatestTaskThread(workspaceRoot);
+}
+
+async function executeReviewRun(request) {
+  ensureCodexAvailable(request.cwd);
+  ensureGitRepository(request.cwd);
+
+  const target = resolveReviewTarget(request.cwd, {
+    base: request.base,
+    scope: request.scope
+  });
+  const focusText = request.focusText?.trim() ?? "";
+  const reviewName = request.reviewName ?? "Review";
+  if (reviewName === "Review") {
+    const reviewTarget = validateNativeReviewRequest(target, focusText);
+    const result = await runAppServerReview(request.cwd, {
+      target: reviewTarget,
+      model: request.model,
+      onProgress: request.onProgress
+    });
+    const payload = {
+      review: reviewName,
+      target,
+      threadId: result.threadId,
+      sourceThreadId: result.sourceThreadId,
+      codex: {
+        status: result.status,
+        stderr: result.stderr,
+        stdout: result.reviewText,
+        reasoning: result.reasoningSummary
+      }
+    };
+    const rendered = renderNativeReviewResult(
+      {
+        status: result.status,
+        stdout: result.reviewText,
+        stderr: result.stderr
+      },
+      { reviewLabel: reviewName, targetLabel: target.label, reasoningSummary: result.reasoningSummary }
+    );
+
+    return {
+      exitStatus: result.status,
+      threadId: result.threadId,
+      turnId: result.turnId,
+      payload,
+      rendered,
+      summary: firstMeaningfulLine(result.reviewText, `${reviewName} completed.`),
+      jobTitle: `Codex ${reviewName}`,
+      jobClass: "review",
+      targetLabel: target.label
+    };
+  }
+
+  const context = collectReviewContext(request.cwd, target);
+  const prompt = buildAdversarialReviewPrompt(context, focusText);
+  const result = await runAppServerTurn(context.repoRoot, {
+    prompt,
+    model: request.model,
+    sandbox: "read-only",
+    outputSchema: readOutputSchema(REVIEW_SCHEMA),
+    onProgress: request.onProgress
+  });
+  const parsed = parseStructuredOutput(result.finalMessage, {
+    status: result.status,
+    failureMessage: result.error?.message ?? result.stderr
+  });
+  const payload = {
+    review: reviewName,
+    target,
+    threadId: result.threadId,
+    context: {
+      repoRoot: context.repoRoot,
+      branch: context.branch,
+      summary: context.summary
+    },
+    codex: {
+      status: result.status,
+      stderr: result.stderr,
+      stdout: result.finalMessage,
+      reasoning: result.reasoningSummary
+    },
+    result: parsed.parsed,
+    rawOutput: parsed.rawOutput,
+    parseError: parsed.parseError,
+    reasoningSummary: result.reasoningSummary
+  };
+
+  return {
+    exitStatus: result.status,
+    threadId: result.threadId,
+    turnId: result.turnId,
+    payload,
+    rendered: renderReviewResult(parsed, {
+      reviewLabel: reviewName,
+      targetLabel: context.target.label,
+      reasoningSummary: result.reasoningSummary
+    }),
+    summary: parsed.parsed?.summary ?? parsed.parseError ?? firstMeaningfulLine(result.finalMessage, `${reviewName} finished.`),
+    jobTitle: `Codex ${reviewName}`,
+    jobClass: "review",
+    targetLabel: context.target.label
+  };
+}
+
+
+async function executeTaskRun(request) {
+  const workspaceRoot = resolveWorkspaceRoot(request.cwd);
+  ensureCodexAvailable(request.cwd);
+
+  const taskMetadata = buildTaskRunMetadata({
+    prompt: request.prompt,
+    resumeLast: request.resumeLast
+  });
+
+  let resumeThreadId = null;
+  if (request.resumeLast) {
+    const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
+      excludeJobId: request.jobId
+    });
+    if (!latestThread) {
+      throw new Error("No previous Codex task thread was found for this repository.");
+    }
+    resumeThreadId = latestThread.id;
+  }
+
+  if (!request.prompt && !resumeThreadId) {
+    throw new Error("Provide a prompt, a prompt file, piped stdin, or use --resume-last.");
+  }
+
+  const result = await runAppServerTurn(workspaceRoot, {
+    resumeThreadId,
+    prompt: request.prompt,
+    defaultPrompt: resumeThreadId ? DEFAULT_CONTINUE_PROMPT : "",
+    model: request.model,
+    effort: request.effort,
+    sandbox: request.write ? "workspace-write" : "read-only",
+    onProgress: request.onProgress,
+    persistThread: true,
+    threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
+  });
+
+  const rawOutput = typeof result.finalMessage === "string" ? result.finalMessage : "";
+  const failureMessage = result.error?.message ?? result.stderr ?? "";
+  const rendered = renderTaskResult(
+    {
+      rawOutput,
+      failureMessage,
+      reasoningSummary: result.reasoningSummary
+    },
+    {
+      title: taskMetadata.title,
+      jobId: request.jobId ?? null,
+      write: Boolean(request.write)
+    }
+  );
+  const payload = {
+    status: result.status,
+    threadId: result.threadId,
+    rawOutput,
+    touchedFiles: result.touchedFiles,
+    reasoningSummary: result.reasoningSummary
+  };
+
+  return {
+    exitStatus: result.status,
+    threadId: result.threadId,
+    turnId: result.turnId,
+    payload,
+    rendered,
+    summary: firstMeaningfulLine(rawOutput, firstMeaningfulLine(failureMessage, `${taskMetadata.title} finished.`)),
+    jobTitle: taskMetadata.title,
+    jobClass: "task",
+    write: Boolean(request.write)
+  };
+}
+
+function buildReviewJobMetadata(reviewName, target) {
+  return {
+    kind: reviewName === "Adversarial Review" ? "adversarial-review" : "review",
+    title: reviewName === "Review" ? "Codex Review" : `Codex ${reviewName}`,
+    summary: `${reviewName} ${target.label}`
+  };
+}
+
+function buildTaskRunMetadata({ prompt, resumeLast = false }) {
+  if (!resumeLast && String(prompt ?? "").includes(STOP_REVIEW_TASK_MARKER)) {
+    return {
+      title: "Codex Stop Gate Review",
+      summary: "Stop-gate review of previous Claude turn"
+    };
+  }
+
+  const title = resumeLast ? "Codex Resume" : "Codex Task";
+  const fallbackSummary = resumeLast ? DEFAULT_CONTINUE_PROMPT : "Task";
+  return {
+    title,
+    summary: shorten(prompt || fallbackSummary)
+  };
+}
+
+function renderQueuedTaskLaunch(payload) {
+  return `${payload.title} started in the background as ${payload.jobId}. Check crew-codex status ${payload.jobId} for progress.\n`;
+}
+
+function getJobKindLabel(kind, jobClass) {
+  if (kind === "adversarial-review") {
+    return "adversarial-review";
+  }
+  return jobClass === "review" ? "review" : "task";
+}
+
+function createCompanionJob({ prefix, kind, title, workspaceRoot, jobClass, summary, write = false }) {
+  return createJobRecord({
+    id: generateJobId(prefix),
+    kind,
+    kindLabel: getJobKindLabel(kind, jobClass),
+    title,
+    workspaceRoot,
+    jobClass,
+    summary,
+    write
+  });
+}
+
+function createTrackedProgress(job, options = {}) {
+  const logFile = options.logFile ?? createJobLogFile(job.workspaceRoot, job.id, job.title);
+  return {
+    logFile,
+    progress: createProgressReporter({
+      stderr: Boolean(options.stderr),
+      logFile,
+      onEvent: createJobProgressUpdater(job.workspaceRoot, job.id)
+    })
+  };
+}
+
+function buildTaskJob(workspaceRoot, taskMetadata, write) {
+  return createCompanionJob({
+    prefix: "task",
+    kind: "task",
+    title: taskMetadata.title,
+    workspaceRoot,
+    jobClass: "task",
+    summary: taskMetadata.summary,
+    write
+  });
+}
+
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+  return {
+    cwd,
+    model,
+    effort,
+    prompt,
+    write,
+    resumeLast,
+    jobId
+  };
+}
+
+function readTaskPrompt(cwd, options, positionals) {
+  if (options["prompt-file"]) {
+    return fs.readFileSync(path.resolve(cwd, options["prompt-file"]), "utf8");
+  }
+
+  const positionalPrompt = positionals.join(" ");
+  return positionalPrompt || readStdinIfPiped();
+}
+
+function requireTaskRequest(prompt, resumeLast) {
+  if (!prompt && !resumeLast) {
+    throw new Error("Provide a prompt, a prompt file, piped stdin, or use --resume-last.");
+  }
+}
+
+async function runForegroundCommand(job, runner, options = {}) {
+  const { logFile, progress } = createTrackedProgress(job, {
+    logFile: options.logFile,
+    stderr: !options.json
+  });
+  const execution = await runTrackedJob(job, () => runner(progress), { logFile });
+  outputResult(options.json ? execution.payload : execution.rendered, options.json);
+  if (execution.exitStatus !== 0) {
+    process.exitCode = execution.exitStatus;
+  }
+  return execution;
+}
+
+function spawnDetachedTaskWorker(cwd, jobId) {
+  const scriptPath = path.join(ROOT_DIR, "scripts", "crew-codex-companion.mjs");
+  const child = spawn(process.execPath, [scriptPath, "task-worker", "--cwd", cwd, "--job-id", jobId], {
+    cwd,
+    env: process.env,
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true
+  });
+  child.unref();
+  return child;
+}
+
+function enqueueBackgroundTask(cwd, job, request) {
+  const { logFile } = createTrackedProgress(job);
+  appendLogLine(logFile, "Queued for background execution.");
+
+  const child = spawnDetachedTaskWorker(cwd, job.id);
+  const queuedRecord = {
+    ...job,
+    status: "queued",
+    phase: "queued",
+    pid: child.pid ?? null,
+    logFile,
+    request
+  };
+  writeJobFile(job.workspaceRoot, job.id, queuedRecord);
+  upsertJob(job.workspaceRoot, queuedRecord);
+
+  return {
+    payload: {
+      jobId: job.id,
+      status: "queued",
+      title: job.title,
+      summary: job.summary,
+      logFile
+    },
+    logFile
+  };
+}
+
+async function handleReviewCommand(argv, config) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["base", "scope", "model", "cwd"],
+    booleanOptions: ["json", "background", "wait"],
+    aliasMap: {
+      m: "model"
+    }
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  const focusText = positionals.join(" ").trim();
+  const target = resolveReviewTarget(cwd, {
+    base: options.base,
+    scope: options.scope
+  });
+
+  config.validateRequest?.(target, focusText);
+  const metadata = buildReviewJobMetadata(config.reviewName, target);
+  const job = createCompanionJob({
+    prefix: "review",
+    kind: metadata.kind,
+    title: metadata.title,
+    workspaceRoot,
+    jobClass: "review",
+    summary: metadata.summary
+  });
+  await runForegroundCommand(
+    job,
+    (progress) =>
+      executeReviewRun({
+        cwd,
+        base: options.base,
+        scope: options.scope,
+        model: options.model,
+        focusText,
+        reviewName: config.reviewName,
+        onProgress: progress
+      }),
+    { json: options.json }
+  );
+}
+
+async function handleReview(argv) {
+  return handleReviewCommand(argv, {
+    reviewName: "Review",
+    validateRequest: validateNativeReviewRequest
+  });
+}
+
+async function handleTask(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["model", "effort", "cwd", "prompt-file"],
+    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    aliasMap: {
+      m: "model"
+    }
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  const model = normalizeRequestedModel(options.model);
+  const effort = normalizeReasoningEffort(options.effort);
+  const prompt = readTaskPrompt(cwd, options, positionals);
+
+  const resumeLast = Boolean(options["resume-last"] || options.resume);
+  const fresh = Boolean(options.fresh);
+  if (resumeLast && fresh) {
+    throw new Error("Choose either --resume/--resume-last or --fresh.");
+  }
+  const write = Boolean(options.write);
+  const taskMetadata = buildTaskRunMetadata({
+    prompt,
+    resumeLast
+  });
+
+  if (options.background) {
+    ensureCodexAvailable(cwd);
+    requireTaskRequest(prompt, resumeLast);
+
+    const job = buildTaskJob(workspaceRoot, taskMetadata, write);
+    const request = buildTaskRequest({
+      cwd,
+      model,
+      effort,
+      prompt,
+      write,
+      resumeLast,
+      jobId: job.id
+    });
+    const { payload } = enqueueBackgroundTask(cwd, job, request);
+    outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
+    return;
+  }
+
+  const job = buildTaskJob(workspaceRoot, taskMetadata, write);
+  await runForegroundCommand(
+    job,
+    (progress) =>
+      executeTaskRun({
+        cwd,
+        model,
+        effort,
+        prompt,
+        write,
+        resumeLast,
+        jobId: job.id,
+        onProgress: progress
+      }),
+    { json: options.json }
+  );
+}
+
+async function handleTaskWorker(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "job-id"]
+  });
+
+  if (!options["job-id"]) {
+    throw new Error("Missing required --job-id for task-worker.");
+  }
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  const storedJob = readStoredJob(workspaceRoot, options["job-id"]);
+  if (!storedJob) {
+    throw new Error(`No stored job found for ${options["job-id"]}.`);
+  }
+
+  const request = storedJob.request;
+  if (!request || typeof request !== "object") {
+    throw new Error(`Stored job ${options["job-id"]} is missing its task request payload.`);
+  }
+
+  const { logFile, progress } = createTrackedProgress(
+    {
+      ...storedJob,
+      workspaceRoot
+    },
+    {
+      logFile: storedJob.logFile ?? null
+    }
+  );
+  await runTrackedJob(
+    {
+      ...storedJob,
+      workspaceRoot,
+      logFile
+    },
+    () =>
+      executeTaskRun({
+        ...request,
+        onProgress: progress
+      }),
+    { logFile }
+  );
+}
+
+async function handleStatus(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "timeout-ms", "poll-interval-ms"],
+    booleanOptions: ["json", "all", "wait"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const reference = positionals[0] ?? "";
+  if (reference) {
+    const snapshot = options.wait
+      ? await waitForSingleJobSnapshot(cwd, reference, {
+          timeoutMs: options["timeout-ms"],
+          pollIntervalMs: options["poll-interval-ms"]
+        })
+      : buildSingleJobSnapshot(cwd, reference);
+    outputCommandResult(snapshot, renderJobStatusReport(snapshot.job), options.json);
+    return;
+  }
+
+  if (options.wait) {
+    throw new Error("`status --wait` requires a job id.");
+  }
+
+  const report = buildStatusSnapshot(cwd, { all: options.all });
+  outputResult(renderStatusPayload(report, options.json), options.json);
+}
+
+function handleResult(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["cwd"],
+    booleanOptions: ["json"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const reference = positionals[0] ?? "";
+  const { workspaceRoot, job } = resolveResultJob(cwd, reference);
+  const storedJob = readStoredJob(workspaceRoot, job.id);
+  const payload = {
+    job,
+    storedJob
+  };
+
+  outputCommandResult(payload, renderStoredJobResult(job, storedJob), options.json);
+}
+
+function handleTaskResumeCandidate(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["cwd"],
+    booleanOptions: ["json"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  const sessionId = getCurrentClaudeSessionId();
+  const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(listJobs(workspaceRoot)));
+  const candidate = findLatestResumableTaskJob(jobs);
+
+  const payload = {
+    available: Boolean(candidate),
+    sessionId,
+    candidate:
+      candidate == null
+        ? null
+        : {
+            id: candidate.id,
+            status: candidate.status,
+            title: candidate.title ?? null,
+            summary: candidate.summary ?? null,
+            threadId: candidate.threadId,
+            completedAt: candidate.completedAt ?? null,
+            updatedAt: candidate.updatedAt ?? null
+          }
+  };
+
+  const rendered = candidate
+    ? `Resumable task found: ${candidate.id} (${candidate.status}).\n`
+    : "No resumable task found for this session.\n";
+  outputCommandResult(payload, rendered, options.json);
+}
+
+async function handleCancel(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["cwd"],
+    booleanOptions: ["json"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const reference = positionals[0] ?? "";
+  const { workspaceRoot, job } = resolveCancelableJob(cwd, reference, { env: process.env });
+  const existing = readStoredJob(workspaceRoot, job.id) ?? {};
+  const threadId = existing.threadId ?? job.threadId ?? null;
+  const turnId = existing.turnId ?? job.turnId ?? null;
+
+  const interrupt = await interruptAppServerTurn(cwd, { threadId, turnId });
+  if (interrupt.attempted) {
+    appendLogLine(
+      job.logFile,
+      interrupt.interrupted
+        ? `Requested Codex turn interrupt for ${turnId} on ${threadId}.`
+        : `Codex turn interrupt failed${interrupt.detail ? `: ${interrupt.detail}` : "."}`
+    );
+  }
+
+  terminateProcessTree(job.pid ?? Number.NaN);
+  appendLogLine(job.logFile, "Cancelled by user.");
+
+  const completedAt = nowIso();
+  const nextJob = {
+    ...job,
+    status: "cancelled",
+    phase: "cancelled",
+    pid: null,
+    completedAt,
+    errorMessage: "Cancelled by user."
+  };
+
+  writeJobFile(workspaceRoot, job.id, {
+    ...existing,
+    ...nextJob,
+    cancelledAt: completedAt
+  });
+  upsertJob(workspaceRoot, {
+    id: job.id,
+    status: "cancelled",
+    phase: "cancelled",
+    pid: null,
+    errorMessage: "Cancelled by user.",
+    completedAt
+  });
+
+  const payload = {
+    jobId: job.id,
+    status: "cancelled",
+    title: job.title,
+    turnInterruptAttempted: interrupt.attempted,
+    turnInterrupted: interrupt.interrupted
+  };
+
+  outputCommandResult(payload, renderCancelReport(nextJob), options.json);
+}
+
+async function main() {
+  const [subcommand, ...argv] = process.argv.slice(2);
+  if (!subcommand || subcommand === "help" || subcommand === "--help") {
+    printUsage();
+    return;
+  }
+
+  switch (subcommand) {
+    case "task":
+      await handleTask(argv);
+      break;
+    case "task-worker":
+      await handleTaskWorker(argv);
+      break;
+    case "status":
+      await handleStatus(argv);
+      break;
+    case "result":
+      handleResult(argv);
+      break;
+    case "task-resume-candidate":
+      handleTaskResumeCandidate(argv);
+      break;
+    case "cancel":
+      await handleCancel(argv);
+      break;
+    default:
+      throw new Error(`Unknown subcommand: ${subcommand}`);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -511,17 +511,18 @@ function enqueueBackgroundTask(cwd, job, request) {
   const { logFile } = createTrackedProgress(job);
   appendLogLine(logFile, "Queued for background execution.");
 
-  const child = spawnDetachedTaskWorker(cwd, job.id);
   const queuedRecord = {
     ...job,
     status: "queued",
     phase: "queued",
-    pid: child.pid ?? null,
+    pid: null,
     logFile,
     request
   };
   writeJobFile(job.workspaceRoot, job.id, queuedRecord);
   upsertJob(job.workspaceRoot, queuedRecord);
+
+  spawnDetachedTaskWorker(cwd, job.id);
 
   return {
     payload: {

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -13,24 +13,15 @@ import {
     buildPersistentTaskThreadName,
     DEFAULT_CONTINUE_PROMPT,
     findLatestTaskThread,
-    getCodexAuthStatus,
     getCodexAvailability,
-    getSessionRuntimeStatus,
     interruptAppServerTurn,
-    parseStructuredOutput,
-    readOutputSchema,
-    runAppServerReview,
     runAppServerTurn
   } from "./crew-codex/lib/codex.mjs";
 import { readStdinIfPiped } from "./crew-codex/lib/fs.mjs";
-import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./crew-codex/lib/git.mjs";
-import { binaryAvailable, terminateProcessTree } from "./crew-codex/lib/process.mjs";
-import { loadPromptTemplate, interpolateTemplate } from "./crew-codex/lib/prompts.mjs";
+import { terminateProcessTree } from "./crew-codex/lib/process.mjs";
 import {
   generateJobId,
-  getConfig,
   listJobs,
-  setConfig,
   upsertJob,
   writeJobFile
 } from "./crew-codex/lib/state.mjs";
@@ -54,18 +45,14 @@ import {
 } from "./crew-codex/lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./crew-codex/lib/workspace.mjs";
 import {
-  renderNativeReviewResult,
-  renderReviewResult,
   renderStoredJobResult,
   renderCancelReport,
   renderJobStatusReport,
-  renderSetupReport,
   renderStatusReport,
   renderTaskResult
 } from "./crew-codex/lib/render.mjs";
 
 const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
-const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
@@ -245,112 +232,11 @@ function parseCrewAgentResult(rawOutput, required = false) {
   }
 }
 
-async function buildSetupReport(cwd, actionsTaken = []) {
-  const workspaceRoot = resolveWorkspaceRoot(cwd);
-  const nodeStatus = binaryAvailable("node", ["--version"], { cwd });
-  const npmStatus = binaryAvailable("npm", ["--version"], { cwd });
-  const codexStatus = getCodexAvailability(cwd);
-  const authStatus = await getCodexAuthStatus(cwd);
-  const config = getConfig(workspaceRoot);
-
-  const nextSteps = [];
-  if (!codexStatus.available) {
-    nextSteps.push("Install Codex with `npm install -g @openai/codex`.");
-  }
-  if (codexStatus.available && !authStatus.loggedIn && authStatus.requiresOpenaiAuth) {
-    nextSteps.push("Run `!codex login`.");
-    nextSteps.push("If browser login is blocked, retry with `!codex login --device-auth` or `!codex login --with-api-key`.");
-  }
-  if (!config.stopReviewGate) {
-    nextSteps.push("Optional: run `/crew-setup --enable-review-gate` to require a fresh review before stop.");
-  }
-
-  return {
-    ready: nodeStatus.available && codexStatus.available && authStatus.loggedIn,
-    node: nodeStatus,
-    npm: npmStatus,
-    codex: codexStatus,
-    auth: authStatus,
-    sessionRuntime: getSessionRuntimeStatus(process.env, workspaceRoot),
-    reviewGateEnabled: Boolean(config.stopReviewGate),
-    actionsTaken,
-    nextSteps
-  };
-}
-
-async function handleSetup(argv) {
-  const { options } = parseCommandInput(argv, {
-    valueOptions: ["cwd"],
-    booleanOptions: ["json", "enable-review-gate", "disable-review-gate"]
-  });
-
-  if (options["enable-review-gate"] && options["disable-review-gate"]) {
-    throw new Error("Choose either --enable-review-gate or --disable-review-gate.");
-  }
-
-  const cwd = resolveCommandCwd(options);
-  const workspaceRoot = resolveCommandWorkspace(options);
-  const actionsTaken = [];
-
-  if (options["enable-review-gate"]) {
-    setConfig(workspaceRoot, "stopReviewGate", true);
-    actionsTaken.push(`Enabled the stop-time review gate for ${workspaceRoot}.`);
-  } else if (options["disable-review-gate"]) {
-    setConfig(workspaceRoot, "stopReviewGate", false);
-    actionsTaken.push(`Disabled the stop-time review gate for ${workspaceRoot}.`);
-  }
-
-  const finalReport = await buildSetupReport(cwd, actionsTaken);
-  outputResult(options.json ? finalReport : renderSetupReport(finalReport), options.json);
-}
-
-function buildAdversarialReviewPrompt(context, focusText) {
-  const template = loadPromptTemplate(ROOT_DIR, "adversarial-review");
-  return interpolateTemplate(template, {
-    REVIEW_KIND: "Adversarial Review",
-    TARGET_LABEL: context.target.label,
-    USER_FOCUS: focusText || "No extra focus provided.",
-    REVIEW_COLLECTION_GUIDANCE: context.collectionGuidance,
-    REVIEW_INPUT: context.content
-  });
-}
-
 function ensureCodexAvailable(cwd) {
   const availability = getCodexAvailability(cwd);
   if (!availability.available) {
     throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/crew-setup`.");
   }
-}
-
-function buildNativeReviewTarget(target) {
-  if (target.mode === "working-tree") {
-    return { type: "uncommittedChanges" };
-  }
-
-  if (target.mode === "branch") {
-    return { type: "baseBranch", branch: target.baseRef };
-  }
-
-  return null;
-}
-
-function validateNativeReviewRequest(target, focusText) {
-  if (focusText.trim()) {
-    throw new Error(
-      `\`crew review\` now maps directly to the built-in reviewer and does not support custom focus text. Retry with \`crew adversarial review ${focusText.trim()}\` for focused review instructions.`
-    );
-  }
-
-  const nativeTarget = buildNativeReviewTarget(target);
-  if (!nativeTarget) {
-    throw new Error("This `crew review` target is not supported by the built-in reviewer. Retry with `crew adversarial review` for custom targeting.");
-  }
-
-  return nativeTarget;
-}
-
-function renderStatusPayload(report, asJson) {
-  return asJson ? report : renderStatusReport(report);
 }
 
 function isActiveJobStatus(status) {
@@ -420,109 +306,6 @@ async function resolveLatestTrackedTaskThread(cwd, options = {}) {
 
   return findLatestTaskThread(workspaceRoot);
 }
-
-async function executeReviewRun(request) {
-  ensureCodexAvailable(request.cwd);
-  ensureGitRepository(request.cwd);
-
-  const target = resolveReviewTarget(request.cwd, {
-    base: request.base,
-    scope: request.scope
-  });
-  const focusText = request.focusText?.trim() ?? "";
-  const reviewName = request.reviewName ?? "Review";
-  if (reviewName === "Review") {
-    const reviewTarget = validateNativeReviewRequest(target, focusText);
-    const result = await runAppServerReview(request.cwd, {
-      target: reviewTarget,
-      model: request.model,
-      onProgress: request.onProgress
-    });
-    const payload = {
-      review: reviewName,
-      target,
-      threadId: result.threadId,
-      sourceThreadId: result.sourceThreadId,
-      codex: {
-        status: result.status,
-        stderr: result.stderr,
-        stdout: result.reviewText,
-        reasoning: result.reasoningSummary
-      }
-    };
-    const rendered = renderNativeReviewResult(
-      {
-        status: result.status,
-        stdout: result.reviewText,
-        stderr: result.stderr
-      },
-      { reviewLabel: reviewName, targetLabel: target.label, reasoningSummary: result.reasoningSummary }
-    );
-
-    return {
-      exitStatus: result.status,
-      threadId: result.threadId,
-      turnId: result.turnId,
-      payload,
-      rendered,
-      summary: firstMeaningfulLine(result.reviewText, `${reviewName} completed.`),
-      jobTitle: `Codex ${reviewName}`,
-      jobClass: "review",
-      targetLabel: target.label
-    };
-  }
-
-  const context = collectReviewContext(request.cwd, target);
-  const prompt = buildAdversarialReviewPrompt(context, focusText);
-  const result = await runAppServerTurn(context.repoRoot, {
-    prompt,
-    model: request.model,
-    sandbox: "read-only",
-    outputSchema: readOutputSchema(REVIEW_SCHEMA),
-    onProgress: request.onProgress
-  });
-  const parsed = parseStructuredOutput(result.finalMessage, {
-    status: result.status,
-    failureMessage: result.error?.message ?? result.stderr
-  });
-  const payload = {
-    review: reviewName,
-    target,
-    threadId: result.threadId,
-    context: {
-      repoRoot: context.repoRoot,
-      branch: context.branch,
-      summary: context.summary
-    },
-    codex: {
-      status: result.status,
-      stderr: result.stderr,
-      stdout: result.finalMessage,
-      reasoning: result.reasoningSummary
-    },
-    result: parsed.parsed,
-    rawOutput: parsed.rawOutput,
-    parseError: parsed.parseError,
-    reasoningSummary: result.reasoningSummary
-  };
-
-  return {
-    exitStatus: result.status,
-    threadId: result.threadId,
-    turnId: result.turnId,
-    payload,
-    rendered: renderReviewResult(parsed, {
-      reviewLabel: reviewName,
-      targetLabel: context.target.label,
-      reasoningSummary: result.reasoningSummary
-    }),
-    summary: parsed.parsed?.summary ?? parsed.parseError ?? firstMeaningfulLine(result.finalMessage, `${reviewName} finished.`),
-    jobTitle: `Codex ${reviewName}`,
-    jobClass: "review",
-    targetLabel: context.target.label
-  };
-}
-
 
 async function executeTaskRun(request) {
   const workspaceRoot = resolveWorkspaceRoot(request.cwd);
@@ -602,14 +385,6 @@ async function executeTaskRun(request) {
     jobTitle: taskMetadata.title,
     jobClass: "task",
     write: Boolean(request.write)
-  };
-}
-
-function buildReviewJobMetadata(reviewName, target) {
-  return {
-    kind: reviewName === "Adversarial Review" ? "adversarial-review" : "review",
-    title: reviewName === "Review" ? "Codex Review" : `Codex ${reviewName}`,
-    summary: `${reviewName} ${target.label}`
   };
 }
 
@@ -759,56 +534,6 @@ function enqueueBackgroundTask(cwd, job, request) {
   };
 }
 
-async function handleReviewCommand(argv, config) {
-  const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd"],
-    booleanOptions: ["json", "background", "wait"],
-    aliasMap: {
-      m: "model"
-    }
-  });
-
-  const cwd = resolveCommandCwd(options);
-  const workspaceRoot = resolveCommandWorkspace(options);
-  const focusText = positionals.join(" ").trim();
-  const target = resolveReviewTarget(cwd, {
-    base: options.base,
-    scope: options.scope
-  });
-
-  config.validateRequest?.(target, focusText);
-  const metadata = buildReviewJobMetadata(config.reviewName, target);
-  const job = createCompanionJob({
-    prefix: "review",
-    kind: metadata.kind,
-    title: metadata.title,
-    workspaceRoot,
-    jobClass: "review",
-    summary: metadata.summary
-  });
-  await runForegroundCommand(
-    job,
-    (progress) =>
-      executeReviewRun({
-        cwd,
-        base: options.base,
-        scope: options.scope,
-        model: options.model,
-        focusText,
-        reviewName: config.reviewName,
-        onProgress: progress
-      }),
-    { json: options.json }
-  );
-}
-
-async function handleReview(argv) {
-  return handleReviewCommand(argv, {
-    reviewName: "Review",
-    validateRequest: validateNativeReviewRequest
-  });
-}
-
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
@@ -944,7 +669,7 @@ async function handleStatus(argv) {
   }
 
   const report = buildStatusSnapshot(cwd, { all: options.all });
-  outputResult(renderStatusPayload(report, options.json), options.json);
+  outputResult(options.json ? report : renderStatusReport(report), options.json);
 }
 
 function handleResult(argv) {

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -58,7 +58,7 @@ const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
-const CREW_AGENT_RESULT_PATTERN = /<crew-agent-result>\s*([\s\S]*?)\s*<\/crew-agent-result>/;
+const CREW_AGENT_RESULT_PATTERN = /<crew-agent-result>\s*([\s\S]*?)\s*<\/crew-agent-result>/g;
 const CREW_AGENT_RESULT_STATUSES = new Set([
   "complete",
   "blocked_on_user",

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -71,12 +71,13 @@ const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
+const CREW_AGENT_RESULT_PATTERN = /<crew-agent-result>\s*([\s\S]*?)\s*<\/crew-agent-result>/;
 
 function printUsage() {
   console.log(
     [
       "Usage:",
-      "  node scripts/crew-codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/crew-codex-companion.mjs task [--background] [--write] [--expect-crew-result] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/crew-codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/crew-codex-companion.mjs result [job-id] [--json]",
       "  node scripts/crew-codex-companion.mjs cancel [job-id] [--json]"
@@ -173,6 +174,28 @@ function firstMeaningfulLine(text, fallback) {
     .map((value) => value.trim())
     .find(Boolean);
   return line ?? fallback;
+}
+
+function parseCrewAgentResult(rawOutput, required = false) {
+  const match = CREW_AGENT_RESULT_PATTERN.exec(String(rawOutput ?? ""));
+  if (!match) {
+    return {
+      result: null,
+      error: required ? "Missing <crew-agent-result> block." : null
+    };
+  }
+
+  try {
+    return {
+      result: JSON.parse(match[1]),
+      error: null
+    };
+  } catch (error) {
+    return {
+      result: null,
+      error: `Invalid <crew-agent-result> JSON: ${error instanceof Error ? error.message : String(error)}`
+    };
+  }
 }
 
 async function buildSetupReport(cwd, actionsTaken = []) {
@@ -511,9 +534,17 @@ async function executeTaskRun(request) {
     touchedFiles: result.touchedFiles,
     reasoningSummary: result.reasoningSummary
   };
+  if (request.expectCrewResult) {
+    const parsedCrewResult = parseCrewAgentResult(rawOutput, true);
+    payload.crewAgentResult = parsedCrewResult.result;
+    payload.crewAgentResultError = parsedCrewResult.error;
+    if (parsedCrewResult.error && result.status === 0) {
+      payload.status = 1;
+    }
+  }
 
   return {
-    exitStatus: result.status,
+    exitStatus: payload.status,
     threadId: result.threadId,
     turnId: result.turnId,
     payload,
@@ -597,7 +628,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, expectCrewResult, jobId }) {
   return {
     cwd,
     model,
@@ -605,6 +636,7 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
+    expectCrewResult,
     jobId
   };
 }
@@ -731,7 +763,7 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    booleanOptions: ["json", "write", "expect-crew-result", "resume-last", "resume", "fresh", "background"],
     aliasMap: {
       m: "model"
     }
@@ -749,6 +781,7 @@ async function handleTask(argv) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
   const write = Boolean(options.write);
+  const expectCrewResult = Boolean(options["expect-crew-result"]);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast
@@ -766,6 +799,7 @@ async function handleTask(argv) {
       prompt,
       write,
       resumeLast,
+      expectCrewResult,
       jobId: job.id
     });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
@@ -784,6 +818,7 @@ async function handleTask(argv) {
         prompt,
         write,
         resumeLast,
+        expectCrewResult,
         jobId: job.id,
         onProgress: progress
       }),

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -540,6 +540,8 @@ async function executeTaskRun(request) {
     payload.crewAgentResultError = parsedCrewResult.error;
     if (parsedCrewResult.error && result.status === 0) {
       payload.status = 1;
+    } else if (parsedCrewResult.result?.status === "failed" && result.status === 0) {
+      payload.status = 1;
     }
   }
 

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -202,8 +202,9 @@ function validateCrewAgentResult(result) {
 }
 
 function parseCrewAgentResult(rawOutput, required = false) {
-  const match = CREW_AGENT_RESULT_PATTERN.exec(String(rawOutput ?? ""));
-  if (!match) {
+  const matches = [...String(rawOutput ?? "").matchAll(CREW_AGENT_RESULT_PATTERN)];
+  const latestMatch = matches.at(-1);
+  if (!latestMatch) {
     return {
       result: null,
       error: required ? "Missing <crew-agent-result> block." : null
@@ -211,7 +212,7 @@ function parseCrewAgentResult(rawOutput, required = false) {
   }
 
   try {
-    const result = JSON.parse(match[1]);
+    const result = JSON.parse(latestMatch[1]);
     const validationError = validateCrewAgentResult(result);
     if (validationError) {
       return {

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -22,6 +22,7 @@ import { terminateProcessTree } from "./crew-codex/lib/process.mjs";
 import {
   generateJobId,
   listJobs,
+  updateJobStateAndFile,
   updateState,
   upsertJob,
   writeJobFile
@@ -526,20 +527,16 @@ function attachQueuedWorkerPid(workspaceRoot, jobId, pid) {
   });
 }
 
-function markActiveJobCancelled(workspaceRoot, jobId, completedAt) {
-  let nextJob = null;
-  updateState(workspaceRoot, (state) => {
-    const existingIndex = state.jobs.findIndex((candidate) => candidate.id === jobId);
-    if (existingIndex === -1) {
-      return;
+function markActiveJobCancelled(workspaceRoot, jobId, completedAt, existingFileJob = {}) {
+  const result = updateJobStateAndFile(workspaceRoot, jobId, (existing) => {
+    if (!existing) {
+      return null;
     }
-
-    const existing = state.jobs[existingIndex];
     if (existing.status !== "queued" && existing.status !== "running") {
-      return;
+      return null;
     }
 
-    nextJob = {
+    const nextJob = {
       ...existing,
       status: "cancelled",
       phase: "cancelled",
@@ -548,9 +545,17 @@ function markActiveJobCancelled(workspaceRoot, jobId, completedAt) {
       updatedAt: completedAt,
       errorMessage: "Cancelled by user."
     };
-    state.jobs[existingIndex] = nextJob;
+
+    return {
+      stateJob: nextJob,
+      fileJob: {
+        ...existingFileJob,
+        ...nextJob,
+        cancelledAt: completedAt
+      }
+    };
   });
-  return nextJob;
+  return result?.job ?? null;
 }
 
 function enqueueBackgroundTask(cwd, job, request) {
@@ -791,7 +796,7 @@ async function handleCancel(argv) {
   const threadId = existing.threadId ?? job.threadId ?? null;
   const turnId = existing.turnId ?? job.turnId ?? null;
   const completedAt = nowIso();
-  const nextJob = markActiveJobCancelled(workspaceRoot, job.id, completedAt);
+  const nextJob = markActiveJobCancelled(workspaceRoot, job.id, completedAt, existing);
   if (!nextJob) {
     throw new Error(`Job ${job.id} is no longer active.`);
   }
@@ -808,12 +813,6 @@ async function handleCancel(argv) {
 
   terminateProcessTree(job.pid ?? Number.NaN);
   appendLogLine(job.logFile, "Cancelled by user.");
-
-  writeJobFile(workspaceRoot, job.id, {
-    ...existing,
-    ...nextJob,
-    cancelledAt: completedAt
-  });
 
   const payload = {
     jobId: job.id,

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -22,6 +22,7 @@ import { terminateProcessTree } from "./crew-codex/lib/process.mjs";
 import {
   generateJobId,
   listJobs,
+  updateState,
   upsertJob,
   writeJobFile
 } from "./crew-codex/lib/state.mjs";
@@ -507,6 +508,24 @@ function spawnDetachedTaskWorker(cwd, jobId) {
   return child;
 }
 
+function attachQueuedWorkerPid(workspaceRoot, jobId, pid) {
+  if (!Number.isFinite(pid)) {
+    return;
+  }
+
+  updateState(workspaceRoot, (state) => {
+    const existingIndex = state.jobs.findIndex((candidate) => candidate.id === jobId);
+    if (existingIndex === -1 || state.jobs[existingIndex].status !== "queued") {
+      return;
+    }
+
+    state.jobs[existingIndex] = {
+      ...state.jobs[existingIndex],
+      pid
+    };
+  });
+}
+
 function enqueueBackgroundTask(cwd, job, request) {
   const { logFile } = createTrackedProgress(job);
   appendLogLine(logFile, "Queued for background execution.");
@@ -522,7 +541,8 @@ function enqueueBackgroundTask(cwd, job, request) {
   writeJobFile(job.workspaceRoot, job.id, queuedRecord);
   upsertJob(job.workspaceRoot, queuedRecord);
 
-  spawnDetachedTaskWorker(cwd, job.id);
+  const child = spawnDetachedTaskWorker(cwd, job.id);
+  attachQueuedWorkerPid(job.workspaceRoot, job.id, child.pid ?? null);
 
   return {
     payload: {

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -526,6 +526,33 @@ function attachQueuedWorkerPid(workspaceRoot, jobId, pid) {
   });
 }
 
+function markActiveJobCancelled(workspaceRoot, jobId, completedAt) {
+  let nextJob = null;
+  updateState(workspaceRoot, (state) => {
+    const existingIndex = state.jobs.findIndex((candidate) => candidate.id === jobId);
+    if (existingIndex === -1) {
+      return;
+    }
+
+    const existing = state.jobs[existingIndex];
+    if (existing.status !== "queued" && existing.status !== "running") {
+      return;
+    }
+
+    nextJob = {
+      ...existing,
+      status: "cancelled",
+      phase: "cancelled",
+      pid: null,
+      completedAt,
+      updatedAt: completedAt,
+      errorMessage: "Cancelled by user."
+    };
+    state.jobs[existingIndex] = nextJob;
+  });
+  return nextJob;
+}
+
 function enqueueBackgroundTask(cwd, job, request) {
   const { logFile } = createTrackedProgress(job);
   appendLogLine(logFile, "Queued for background execution.");
@@ -636,6 +663,10 @@ async function handleTaskWorker(argv) {
   const storedJob = readStoredJob(workspaceRoot, options["job-id"]);
   if (!storedJob) {
     throw new Error(`No stored job found for ${options["job-id"]}.`);
+  }
+  if (storedJob.status !== "queued") {
+    appendLogLine(storedJob.logFile, `Skipping background worker because job is ${storedJob.status}.`);
+    return;
   }
 
   const request = storedJob.request;
@@ -759,6 +790,11 @@ async function handleCancel(argv) {
   const existing = readStoredJob(workspaceRoot, job.id) ?? {};
   const threadId = existing.threadId ?? job.threadId ?? null;
   const turnId = existing.turnId ?? job.turnId ?? null;
+  const completedAt = nowIso();
+  const nextJob = markActiveJobCancelled(workspaceRoot, job.id, completedAt);
+  if (!nextJob) {
+    throw new Error(`Job ${job.id} is no longer active.`);
+  }
 
   const interrupt = await interruptAppServerTurn(cwd, { threadId, turnId });
   if (interrupt.attempted) {
@@ -773,28 +809,10 @@ async function handleCancel(argv) {
   terminateProcessTree(job.pid ?? Number.NaN);
   appendLogLine(job.logFile, "Cancelled by user.");
 
-  const completedAt = nowIso();
-  const nextJob = {
-    ...job,
-    status: "cancelled",
-    phase: "cancelled",
-    pid: null,
-    completedAt,
-    errorMessage: "Cancelled by user."
-  };
-
   writeJobFile(workspaceRoot, job.id, {
     ...existing,
     ...nextJob,
     cancelledAt: completedAt
-  });
-  upsertJob(workspaceRoot, {
-    id: job.id,
-    status: "cancelled",
-    phase: "cancelled",
-    pid: null,
-    errorMessage: "Cancelled by user.",
-    completedAt
   });
 
   const payload = {

--- a/scripts/crew-codex-companion.mjs
+++ b/scripts/crew-codex-companion.mjs
@@ -72,6 +72,13 @@ const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "hi
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 const CREW_AGENT_RESULT_PATTERN = /<crew-agent-result>\s*([\s\S]*?)\s*<\/crew-agent-result>/;
+const CREW_AGENT_RESULT_STATUSES = new Set([
+  "complete",
+  "blocked_on_user",
+  "needs_agent",
+  "needs_tool",
+  "failed"
+]);
 
 function printUsage() {
   console.log(
@@ -176,6 +183,37 @@ function firstMeaningfulLine(text, fallback) {
   return line ?? fallback;
 }
 
+function validateCrewAgentResult(result) {
+  if (result == null || typeof result !== "object" || Array.isArray(result)) {
+    return "AgentResult must be a JSON object.";
+  }
+
+  if (!CREW_AGENT_RESULT_STATUSES.has(result.status)) {
+    return `AgentResult status must be one of: ${Array.from(CREW_AGENT_RESULT_STATUSES).join(", ")}.`;
+  }
+
+  if ("questions" in result && !Array.isArray(result.questions)) {
+    return "AgentResult questions must be an array when provided.";
+  }
+
+  if ("requests" in result && !Array.isArray(result.requests)) {
+    return "AgentResult requests must be an array when provided.";
+  }
+
+  if (result.status === "blocked_on_user" && (!Array.isArray(result.questions) || result.questions.length === 0)) {
+    return "AgentResult blocked_on_user requires a non-empty questions array.";
+  }
+
+  if (
+    (result.status === "needs_agent" || result.status === "needs_tool") &&
+    (!Array.isArray(result.requests) || result.requests.length === 0)
+  ) {
+    return `AgentResult ${result.status} requires a non-empty requests array.`;
+  }
+
+  return null;
+}
+
 function parseCrewAgentResult(rawOutput, required = false) {
   const match = CREW_AGENT_RESULT_PATTERN.exec(String(rawOutput ?? ""));
   if (!match) {
@@ -186,8 +224,17 @@ function parseCrewAgentResult(rawOutput, required = false) {
   }
 
   try {
+    const result = JSON.parse(match[1]);
+    const validationError = validateCrewAgentResult(result);
+    if (validationError) {
+      return {
+        result,
+        error: validationError
+      };
+    }
+
     return {
-      result: JSON.parse(match[1]),
+      result,
       error: null
     };
   } catch (error) {

--- a/scripts/crew-codex/LICENSE
+++ b/scripts/crew-codex/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/scripts/crew-codex/NOTICE
+++ b/scripts/crew-codex/NOTICE
@@ -1,0 +1,16 @@
+Copyright 2026 OpenAI
+
+Modified by claude-crew contributors in 2026 for embedded Codex app-server
+runtime integration.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/scripts/crew-codex/app-server-broker.mjs
+++ b/scripts/crew-codex/app-server-broker.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import process from "node:process";
+
+import { parseArgs } from "./lib/args.mjs";
+import { BROKER_BUSY_RPC_CODE, CodexAppServerClient } from "./lib/app-server.mjs";
+import { parseBrokerEndpoint } from "./lib/broker-endpoint.mjs";
+
+const STREAMING_METHODS = new Set(["turn/start", "review/start", "thread/compact/start"]);
+
+function buildStreamThreadIds(method, params, result) {
+  const threadIds = new Set();
+  if (params?.threadId) {
+    threadIds.add(params.threadId);
+  }
+  if (method === "review/start" && result?.reviewThreadId) {
+    threadIds.add(result.reviewThreadId);
+  }
+  return threadIds;
+}
+
+function buildJsonRpcError(code, message, data) {
+  return data === undefined ? { code, message } : { code, message, data };
+}
+
+function send(socket, message) {
+  if (socket.destroyed) {
+    return;
+  }
+  socket.write(`${JSON.stringify(message)}\n`);
+}
+
+function isInterruptRequest(message) {
+  return message?.method === "turn/interrupt";
+}
+
+function writePidFile(pidFile) {
+  if (!pidFile) {
+    return;
+  }
+  fs.mkdirSync(path.dirname(pidFile), { recursive: true });
+  fs.writeFileSync(pidFile, `${process.pid}\n`, "utf8");
+}
+
+async function main() {
+  const [subcommand, ...argv] = process.argv.slice(2);
+  if (subcommand !== "serve") {
+    throw new Error("Usage: node scripts/app-server-broker.mjs serve --endpoint <value> [--cwd <path>] [--pid-file <path>]");
+  }
+
+  const { options } = parseArgs(argv, {
+    valueOptions: ["cwd", "pid-file", "endpoint"]
+  });
+
+  if (!options.endpoint) {
+    throw new Error("Missing required --endpoint.");
+  }
+
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const endpoint = String(options.endpoint);
+  const listenTarget = parseBrokerEndpoint(endpoint);
+  const pidFile = options["pid-file"] ? path.resolve(options["pid-file"]) : null;
+  writePidFile(pidFile);
+
+  const appClient = await CodexAppServerClient.connect(cwd, { disableBroker: true });
+  let activeRequestSocket = null;
+  let activeStreamSocket = null;
+  let activeStreamThreadIds = null;
+  const sockets = new Set();
+
+  function clearSocketOwnership(socket) {
+    if (activeRequestSocket === socket) {
+      activeRequestSocket = null;
+    }
+    if (activeStreamSocket === socket) {
+      activeStreamSocket = null;
+      activeStreamThreadIds = null;
+    }
+  }
+
+  function routeNotification(message) {
+    const target = activeRequestSocket ?? activeStreamSocket;
+    if (!target) {
+      return;
+    }
+    send(target, message);
+    if (message.method === "turn/completed" && activeStreamSocket === target) {
+      const threadId = message.params?.threadId ?? null;
+      if (!threadId || !activeStreamThreadIds || activeStreamThreadIds.has(threadId)) {
+        activeStreamSocket = null;
+        activeStreamThreadIds = null;
+        if (activeRequestSocket === target) {
+          activeRequestSocket = null;
+        }
+      }
+    }
+  }
+
+  async function shutdown(server) {
+    for (const socket of sockets) {
+      socket.end();
+    }
+    await appClient.close().catch(() => {});
+    await new Promise((resolve) => server.close(resolve));
+    if (listenTarget.kind === "unix" && fs.existsSync(listenTarget.path)) {
+      fs.unlinkSync(listenTarget.path);
+    }
+    if (pidFile && fs.existsSync(pidFile)) {
+      fs.unlinkSync(pidFile);
+    }
+  }
+
+  appClient.setNotificationHandler(routeNotification);
+
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.setEncoding("utf8");
+    let buffer = "";
+
+    socket.on("data", async (chunk) => {
+      buffer += chunk;
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        newlineIndex = buffer.indexOf("\n");
+
+        if (!line.trim()) {
+          continue;
+        }
+
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch (error) {
+          send(socket, {
+            id: null,
+            error: buildJsonRpcError(-32700, `Invalid JSON: ${error.message}`)
+          });
+          continue;
+        }
+
+        if (message.id !== undefined && message.method === "initialize") {
+          send(socket, {
+            id: message.id,
+            result: {
+              userAgent: "claude-crew-codex-broker"
+            }
+          });
+          continue;
+        }
+
+        if (message.method === "initialized" && message.id === undefined) {
+          continue;
+        }
+
+        if (message.id !== undefined && message.method === "broker/shutdown") {
+          send(socket, { id: message.id, result: {} });
+          await shutdown(server);
+          process.exit(0);
+        }
+
+        if (message.id === undefined) {
+          continue;
+        }
+
+        const allowInterruptDuringActiveStream =
+          isInterruptRequest(message) && activeStreamSocket && activeStreamSocket !== socket && !activeRequestSocket;
+
+        if (
+          ((activeRequestSocket && activeRequestSocket !== socket) || (activeStreamSocket && activeStreamSocket !== socket)) &&
+          !allowInterruptDuringActiveStream
+        ) {
+          send(socket, {
+            id: message.id,
+            error: buildJsonRpcError(BROKER_BUSY_RPC_CODE, "Shared Codex broker is busy.")
+          });
+          continue;
+        }
+
+        if (allowInterruptDuringActiveStream) {
+          try {
+            const result = await appClient.request(message.method, message.params ?? {});
+            send(socket, { id: message.id, result });
+          } catch (error) {
+            send(socket, {
+              id: message.id,
+              error: buildJsonRpcError(error.rpcCode ?? -32000, error.message)
+            });
+          }
+          continue;
+        }
+
+        const isStreaming = STREAMING_METHODS.has(message.method);
+        activeRequestSocket = socket;
+
+        try {
+          const result = await appClient.request(message.method, message.params ?? {});
+          send(socket, { id: message.id, result });
+          if (isStreaming) {
+            activeStreamSocket = socket;
+            activeStreamThreadIds = buildStreamThreadIds(message.method, message.params ?? {}, result);
+          }
+          if (activeRequestSocket === socket) {
+            activeRequestSocket = null;
+          }
+        } catch (error) {
+          send(socket, {
+            id: message.id,
+            error: buildJsonRpcError(error.rpcCode ?? -32000, error.message)
+          });
+          if (activeRequestSocket === socket) {
+            activeRequestSocket = null;
+          }
+          if (activeStreamSocket === socket && !isStreaming) {
+            activeStreamSocket = null;
+          }
+        }
+      }
+    });
+
+    socket.on("close", () => {
+      sockets.delete(socket);
+      clearSocketOwnership(socket);
+    });
+
+    socket.on("error", () => {
+      sockets.delete(socket);
+      clearSocketOwnership(socket);
+    });
+  });
+
+  process.on("SIGTERM", async () => {
+    await shutdown(server);
+    process.exit(0);
+  });
+
+  process.on("SIGINT", async () => {
+    await shutdown(server);
+    process.exit(0);
+  });
+
+  server.listen(listenTarget.path);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/scripts/crew-codex/lib/app-server.mjs
+++ b/scripts/crew-codex/lib/app-server.mjs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+/**
+ * @typedef {Error & { data?: unknown, rpcCode?: number }} ProtocolError
+ * @typedef {import("./app-server-protocol").AppServerMethod} AppServerMethod
+ * @typedef {import("./app-server-protocol").AppServerNotification} AppServerNotification
+ * @typedef {import("./app-server-protocol").AppServerNotificationHandler} AppServerNotificationHandler
+ * @typedef {import("./app-server-protocol").ClientInfo} ClientInfo
+ * @typedef {import("./app-server-protocol").CodexAppServerClientOptions} CodexAppServerClientOptions
+ * @typedef {import("./app-server-protocol").InitializeCapabilities} InitializeCapabilities
+ */
+import fs from "node:fs";
+import net from "node:net";
+import process from "node:process";
+import { spawn } from "node:child_process";
+import readline from "node:readline";
+import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
+import { ensureBrokerSession, loadBrokerSession } from "./broker-lifecycle.mjs";
+import { terminateProcessTree } from "./process.mjs";
+
+const PLUGIN_MANIFEST_URL = new URL("../../../.claude-plugin/plugin.json", import.meta.url);
+const PLUGIN_MANIFEST = JSON.parse(fs.readFileSync(PLUGIN_MANIFEST_URL, "utf8"));
+
+export const BROKER_ENDPOINT_ENV = "CODEX_COMPANION_APP_SERVER_ENDPOINT";
+export const BROKER_BUSY_RPC_CODE = -32001;
+
+/** @type {ClientInfo} */
+const DEFAULT_CLIENT_INFO = {
+  title: "Claude Crew Codex Runtime",
+  name: "claude-crew",
+  version: PLUGIN_MANIFEST.version ?? "0.0.0"
+};
+
+/** @type {InitializeCapabilities} */
+const DEFAULT_CAPABILITIES = {
+  experimentalApi: false,
+  optOutNotificationMethods: [
+    "item/agentMessage/delta",
+    "item/reasoning/summaryTextDelta",
+    "item/reasoning/summaryPartAdded",
+    "item/reasoning/textDelta"
+  ]
+};
+
+function buildJsonRpcError(code, message, data) {
+  return data === undefined ? { code, message } : { code, message, data };
+}
+
+function createProtocolError(message, data) {
+  const error = /** @type {ProtocolError} */ (new Error(message));
+  error.data = data;
+  if (data?.code !== undefined) {
+    error.rpcCode = data.code;
+  }
+  return error;
+}
+
+class AppServerClientBase {
+  constructor(cwd, options = {}) {
+    this.cwd = cwd;
+    this.options = options;
+    this.pending = new Map();
+    this.nextId = 1;
+    this.stderr = "";
+    this.closed = false;
+    this.exitError = null;
+    /** @type {AppServerNotificationHandler | null} */
+    this.notificationHandler = null;
+    this.lineBuffer = "";
+    this.transport = "unknown";
+
+    this.exitPromise = new Promise((resolve) => {
+      this.resolveExit = resolve;
+    });
+  }
+
+  setNotificationHandler(handler) {
+    this.notificationHandler = handler;
+  }
+
+  /**
+   * @template {AppServerMethod} M
+   * @param {M} method
+   * @param {import("./app-server-protocol").AppServerRequestParams<M>} params
+   * @returns {Promise<import("./app-server-protocol").AppServerResponse<M>>}
+   */
+  request(method, params) {
+    if (this.closed) {
+      throw new Error("codex app-server client is closed.");
+    }
+
+    const id = this.nextId;
+    this.nextId += 1;
+
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject, method });
+      this.sendMessage({ id, method, params });
+    });
+  }
+
+  notify(method, params = {}) {
+    if (this.closed) {
+      return;
+    }
+    this.sendMessage({ method, params });
+  }
+
+  handleChunk(chunk) {
+    this.lineBuffer += chunk;
+    let newlineIndex = this.lineBuffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = this.lineBuffer.slice(0, newlineIndex);
+      this.lineBuffer = this.lineBuffer.slice(newlineIndex + 1);
+      this.handleLine(line);
+      newlineIndex = this.lineBuffer.indexOf("\n");
+    }
+  }
+
+  handleLine(line) {
+    if (!line.trim()) {
+      return;
+    }
+
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch (error) {
+      this.handleExit(createProtocolError(`Failed to parse codex app-server JSONL: ${error.message}`, { line }));
+      return;
+    }
+
+    if (message.id !== undefined && message.method) {
+      this.handleServerRequest(message);
+      return;
+    }
+
+    if (message.id !== undefined) {
+      const pending = this.pending.get(message.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(message.id);
+
+      if (message.error) {
+        pending.reject(createProtocolError(message.error.message ?? `codex app-server ${pending.method} failed.`, message.error));
+      } else {
+        pending.resolve(message.result ?? {});
+      }
+      return;
+    }
+
+    if (message.method && this.notificationHandler) {
+      this.notificationHandler(/** @type {AppServerNotification} */ (message));
+    }
+  }
+
+  handleServerRequest(message) {
+    this.sendMessage({
+      id: message.id,
+      error: buildJsonRpcError(-32601, `Unsupported server request: ${message.method}`)
+    });
+  }
+
+  handleExit(error) {
+    if (this.exitResolved) {
+      return;
+    }
+
+    this.exitResolved = true;
+    this.exitError = error ?? null;
+
+    for (const pending of this.pending.values()) {
+      pending.reject(this.exitError ?? new Error("codex app-server connection closed."));
+    }
+    this.pending.clear();
+    this.resolveExit(undefined);
+  }
+
+  sendMessage(_message) {
+    throw new Error("sendMessage must be implemented by subclasses.");
+  }
+}
+
+class SpawnedCodexAppServerClient extends AppServerClientBase {
+  constructor(cwd, options = {}) {
+    super(cwd, options);
+    this.transport = "direct";
+  }
+
+  async initialize() {
+    this.proc = spawn("codex", ["app-server"], {
+      cwd: this.cwd,
+      env: this.options.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+      windowsHide: true
+    });
+
+    this.proc.stdout.setEncoding("utf8");
+    this.proc.stderr.setEncoding("utf8");
+
+    this.proc.stderr.on("data", (chunk) => {
+      this.stderr += chunk;
+    });
+
+    this.proc.on("error", (error) => {
+      this.handleExit(error);
+    });
+
+    this.proc.on("exit", (code, signal) => {
+      const detail =
+        code === 0
+          ? null
+          : createProtocolError(`codex app-server exited unexpectedly (${signal ? `signal ${signal}` : `exit ${code}`}).`);
+      this.handleExit(detail);
+    });
+
+    this.readline = readline.createInterface({ input: this.proc.stdout });
+    this.readline.on("line", (line) => {
+      this.handleLine(line);
+    });
+
+    await this.request("initialize", {
+      clientInfo: this.options.clientInfo ?? DEFAULT_CLIENT_INFO,
+      capabilities: this.options.capabilities ?? DEFAULT_CAPABILITIES
+    });
+    this.notify("initialized", {});
+  }
+
+  async close() {
+    if (this.closed) {
+      await this.exitPromise;
+      return;
+    }
+
+    this.closed = true;
+
+    if (this.readline) {
+      this.readline.close();
+    }
+
+    if (this.proc && !this.proc.killed) {
+      this.proc.stdin.end();
+      setTimeout(() => {
+        if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
+          // On Windows with shell: true, the direct child is cmd.exe.
+          // Use terminateProcessTree to kill the entire tree including
+          // the grandchild node process.
+          if (process.platform === "win32") {
+            try {
+              terminateProcessTree(this.proc.pid);
+            } catch {
+              // Best-effort cleanup inside an unref'd timer — swallow errors
+              // to avoid crashing the host process during shutdown.
+            }
+          } else {
+            this.proc.kill("SIGTERM");
+          }
+        }
+      }, 50).unref?.();
+    }
+
+    await this.exitPromise;
+  }
+
+  sendMessage(message) {
+    const line = `${JSON.stringify(message)}\n`;
+    const stdin = this.proc?.stdin;
+    if (!stdin) {
+      throw new Error("codex app-server stdin is not available.");
+    }
+    stdin.write(line);
+  }
+}
+
+class BrokerCodexAppServerClient extends AppServerClientBase {
+  constructor(cwd, options = {}) {
+    super(cwd, options);
+    this.transport = "broker";
+    this.endpoint = options.brokerEndpoint;
+  }
+
+  async initialize() {
+    await new Promise((resolve, reject) => {
+      const target = parseBrokerEndpoint(this.endpoint);
+      this.socket = net.createConnection({ path: target.path });
+      this.socket.setEncoding("utf8");
+      this.socket.on("connect", resolve);
+      this.socket.on("data", (chunk) => {
+        this.handleChunk(chunk);
+      });
+      this.socket.on("error", (error) => {
+        if (!this.exitResolved) {
+          reject(error);
+        }
+        this.handleExit(error);
+      });
+      this.socket.on("close", () => {
+        this.handleExit(this.exitError);
+      });
+    });
+
+    await this.request("initialize", {
+      clientInfo: this.options.clientInfo ?? DEFAULT_CLIENT_INFO,
+      capabilities: this.options.capabilities ?? DEFAULT_CAPABILITIES
+    });
+    this.notify("initialized", {});
+  }
+
+  async close() {
+    if (this.closed) {
+      await this.exitPromise;
+      return;
+    }
+
+    this.closed = true;
+    if (this.socket) {
+      this.socket.end();
+    }
+    await this.exitPromise;
+  }
+
+  sendMessage(message) {
+    const line = `${JSON.stringify(message)}\n`;
+    const socket = this.socket;
+    if (!socket) {
+      throw new Error("codex app-server broker connection is not connected.");
+    }
+    socket.write(line);
+  }
+}
+
+export class CodexAppServerClient {
+  static async connect(cwd, options = {}) {
+    let brokerEndpoint = null;
+    if (!options.disableBroker) {
+      brokerEndpoint = options.brokerEndpoint ?? options.env?.[BROKER_ENDPOINT_ENV] ?? process.env[BROKER_ENDPOINT_ENV] ?? null;
+      if (!brokerEndpoint && options.reuseExistingBroker) {
+        brokerEndpoint = loadBrokerSession(cwd)?.endpoint ?? null;
+      }
+      if (!brokerEndpoint && !options.reuseExistingBroker) {
+        const brokerSession = await ensureBrokerSession(cwd, { env: options.env });
+        brokerEndpoint = brokerSession?.endpoint ?? null;
+      }
+    }
+    const client = brokerEndpoint
+      ? new BrokerCodexAppServerClient(cwd, { ...options, brokerEndpoint })
+      : new SpawnedCodexAppServerClient(cwd, options);
+    await client.initialize();
+    return client;
+  }
+}

--- a/scripts/crew-codex/lib/app-server.mjs
+++ b/scripts/crew-codex/lib/app-server.mjs
@@ -192,7 +192,7 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
       cwd: this.cwd,
       env: this.options.env ?? process.env,
       stdio: ["pipe", "pipe", "pipe"],
-      shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+      shell: process.platform === "win32",
       windowsHide: true
     });
 

--- a/scripts/crew-codex/lib/args.mjs
+++ b/scripts/crew-codex/lib/args.mjs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+export function parseArgs(argv, config = {}) {
+  const valueOptions = new Set(config.valueOptions ?? []);
+  const booleanOptions = new Set(config.booleanOptions ?? []);
+  const aliasMap = config.aliasMap ?? {};
+  const options = {};
+  const positionals = [];
+  let passthrough = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (passthrough) {
+      positionals.push(token);
+      continue;
+    }
+
+    if (token === "--") {
+      passthrough = true;
+      continue;
+    }
+
+    if (!token.startsWith("-") || token === "-") {
+      positionals.push(token);
+      continue;
+    }
+
+    if (token.startsWith("--")) {
+      const [rawKey, inlineValue] = token.slice(2).split("=", 2);
+      const key = aliasMap[rawKey] ?? rawKey;
+
+      if (booleanOptions.has(key)) {
+        options[key] = inlineValue === undefined ? true : inlineValue !== "false";
+        continue;
+      }
+
+      if (valueOptions.has(key)) {
+        const nextValue = inlineValue ?? argv[index + 1];
+        if (nextValue === undefined) {
+          throw new Error(`Missing value for --${rawKey}`);
+        }
+        options[key] = nextValue;
+        if (inlineValue === undefined) {
+          index += 1;
+        }
+        continue;
+      }
+
+      positionals.push(token);
+      continue;
+    }
+
+    const shortKey = token.slice(1);
+    const key = aliasMap[shortKey] ?? shortKey;
+
+    if (booleanOptions.has(key)) {
+      options[key] = true;
+      continue;
+    }
+
+    if (valueOptions.has(key)) {
+      const nextValue = argv[index + 1];
+      if (nextValue === undefined) {
+        throw new Error(`Missing value for -${shortKey}`);
+      }
+      options[key] = nextValue;
+      index += 1;
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { options, positionals };
+}
+
+export function splitRawArgumentString(raw) {
+  const tokens = [];
+  let current = "";
+  let quote = null;
+  let escaping = false;
+
+  for (const character of raw) {
+    if (escaping) {
+      current += character;
+      escaping = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === "\"") {
+      quote = character;
+      continue;
+    }
+
+    if (/\s/.test(character)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+
+  if (current) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}

--- a/scripts/crew-codex/lib/broker-endpoint.mjs
+++ b/scripts/crew-codex/lib/broker-endpoint.mjs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import path from "node:path";
+import process from "node:process";
+
+function sanitizePipeName(value) {
+  return String(value ?? "")
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function createBrokerEndpoint(sessionDir, platform = process.platform) {
+  if (platform === "win32") {
+    const pipeName = sanitizePipeName(`${path.win32.basename(sessionDir)}-codex-app-server`);
+    return `pipe:\\\\.\\pipe\\${pipeName}`;
+  }
+
+  return `unix:${path.join(sessionDir, "broker.sock")}`;
+}
+
+export function parseBrokerEndpoint(endpoint) {
+  if (typeof endpoint !== "string" || endpoint.length === 0) {
+    throw new Error("Missing broker endpoint.");
+  }
+
+  if (endpoint.startsWith("pipe:")) {
+    const pipePath = endpoint.slice("pipe:".length);
+    if (!pipePath) {
+      throw new Error("Broker pipe endpoint is missing its path.");
+    }
+    return { kind: "pipe", path: pipePath };
+  }
+
+  if (endpoint.startsWith("unix:")) {
+    const socketPath = endpoint.slice("unix:".length);
+    if (!socketPath) {
+      throw new Error("Broker Unix socket endpoint is missing its path.");
+    }
+    return { kind: "unix", path: socketPath };
+  }
+
+  throw new Error(`Unsupported broker endpoint: ${endpoint}`);
+}

--- a/scripts/crew-codex/lib/broker-lifecycle.mjs
+++ b/scripts/crew-codex/lib/broker-lifecycle.mjs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { createBrokerEndpoint, parseBrokerEndpoint } from "./broker-endpoint.mjs";
+import { resolveStateDir } from "./state.mjs";
+
+export const PID_FILE_ENV = "CODEX_COMPANION_APP_SERVER_PID_FILE";
+export const LOG_FILE_ENV = "CODEX_COMPANION_APP_SERVER_LOG_FILE";
+const BROKER_STATE_FILE = "broker.json";
+
+export function createBrokerSessionDir(prefix = "cxc-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function connectToEndpoint(endpoint) {
+  const target = parseBrokerEndpoint(endpoint);
+  return net.createConnection({ path: target.path });
+}
+
+export async function waitForBrokerEndpoint(endpoint, timeoutMs = 2000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const ready = await new Promise((resolve) => {
+      const socket = connectToEndpoint(endpoint);
+      socket.on("connect", () => {
+        socket.end();
+        resolve(true);
+      });
+      socket.on("error", () => resolve(false));
+    });
+    if (ready) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
+export async function sendBrokerShutdown(endpoint) {
+  await new Promise((resolve) => {
+    const socket = connectToEndpoint(endpoint);
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write(`${JSON.stringify({ id: 1, method: "broker/shutdown", params: {} })}\n`);
+    });
+    socket.on("data", () => {
+      socket.end();
+      resolve();
+    });
+    socket.on("error", resolve);
+    socket.on("close", resolve);
+  });
+}
+
+export function spawnBrokerProcess({ scriptPath, cwd, endpoint, pidFile, logFile, env = process.env }) {
+  const logFd = fs.openSync(logFile, "a");
+  const child = spawn(process.execPath, [scriptPath, "serve", "--endpoint", endpoint, "--cwd", cwd, "--pid-file", pidFile], {
+    cwd,
+    env,
+    detached: true,
+    stdio: ["ignore", logFd, logFd]
+  });
+  child.unref();
+  fs.closeSync(logFd);
+  return child;
+}
+
+function resolveBrokerStateFile(cwd) {
+  return path.join(resolveStateDir(cwd), BROKER_STATE_FILE);
+}
+
+export function loadBrokerSession(cwd) {
+  const stateFile = resolveBrokerStateFile(cwd);
+  if (!fs.existsSync(stateFile)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function saveBrokerSession(cwd, session) {
+  const stateDir = resolveStateDir(cwd);
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(resolveBrokerStateFile(cwd), `${JSON.stringify(session, null, 2)}\n`, "utf8");
+}
+
+export function clearBrokerSession(cwd) {
+  const stateFile = resolveBrokerStateFile(cwd);
+  if (fs.existsSync(stateFile)) {
+    fs.unlinkSync(stateFile);
+  }
+}
+
+async function isBrokerEndpointReady(endpoint) {
+  if (!endpoint) {
+    return false;
+  }
+  try {
+    return await waitForBrokerEndpoint(endpoint, 150);
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureBrokerSession(cwd, options = {}) {
+  const existing = loadBrokerSession(cwd);
+  if (existing && (await isBrokerEndpointReady(existing.endpoint))) {
+    return existing;
+  }
+
+  if (existing) {
+    teardownBrokerSession({
+      endpoint: existing.endpoint ?? null,
+      pidFile: existing.pidFile ?? null,
+      logFile: existing.logFile ?? null,
+      sessionDir: existing.sessionDir ?? null,
+      pid: existing.pid ?? null,
+      killProcess: options.killProcess ?? null
+    });
+    clearBrokerSession(cwd);
+  }
+
+  const sessionDir = createBrokerSessionDir();
+  const endpointFactory = options.createBrokerEndpoint ?? createBrokerEndpoint;
+  const endpoint = endpointFactory(sessionDir, options.platform);
+  const pidFile = path.join(sessionDir, "broker.pid");
+  const logFile = path.join(sessionDir, "broker.log");
+  const scriptPath =
+    options.scriptPath ??
+    fileURLToPath(new URL("../app-server-broker.mjs", import.meta.url));
+
+  const child = spawnBrokerProcess({
+    scriptPath,
+    cwd,
+    endpoint,
+    pidFile,
+    logFile,
+    env: options.env ?? process.env
+  });
+
+  const ready = await waitForBrokerEndpoint(endpoint, options.timeoutMs ?? 2000);
+  if (!ready) {
+    teardownBrokerSession({
+      endpoint,
+      pidFile,
+      logFile,
+      sessionDir,
+      pid: child.pid ?? null,
+      killProcess: options.killProcess ?? null
+    });
+    return null;
+  }
+
+  const session = {
+    endpoint,
+    pidFile,
+    logFile,
+    sessionDir,
+    pid: child.pid ?? null
+  };
+  saveBrokerSession(cwd, session);
+  return session;
+}
+
+export function teardownBrokerSession({ endpoint = null, pidFile, logFile, sessionDir = null, pid = null, killProcess = null }) {
+  if (Number.isFinite(pid) && killProcess) {
+    try {
+      killProcess(pid);
+    } catch {
+      // Ignore missing or already-exited broker processes.
+    }
+  }
+
+  if (pidFile && fs.existsSync(pidFile)) {
+    fs.unlinkSync(pidFile);
+  }
+
+  if (logFile && fs.existsSync(logFile)) {
+    fs.unlinkSync(logFile);
+  }
+
+  if (endpoint) {
+    try {
+      const target = parseBrokerEndpoint(endpoint);
+      if (target.kind === "unix" && fs.existsSync(target.path)) {
+        fs.unlinkSync(target.path);
+      }
+    } catch {
+      // Ignore malformed or already-removed broker endpoints during teardown.
+    }
+  }
+
+  const resolvedSessionDir = sessionDir ?? (pidFile ? path.dirname(pidFile) : logFile ? path.dirname(logFile) : null);
+  if (resolvedSessionDir && fs.existsSync(resolvedSessionDir)) {
+    try {
+      fs.rmdirSync(resolvedSessionDir);
+    } catch {
+      // Ignore non-empty or missing directories.
+    }
+  }
+}

--- a/scripts/crew-codex/lib/broker-lifecycle.mjs
+++ b/scripts/crew-codex/lib/broker-lifecycle.mjs
@@ -8,7 +8,7 @@ import process from "node:process";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createBrokerEndpoint, parseBrokerEndpoint } from "./broker-endpoint.mjs";
-import { resolveStateDir } from "./state.mjs";
+import { resolveStateDir, withStateLockAsync, writeJsonFileAtomic } from "./state.mjs";
 
 export const PID_FILE_ENV = "CODEX_COMPANION_APP_SERVER_PID_FILE";
 export const LOG_FILE_ENV = "CODEX_COMPANION_APP_SERVER_LOG_FILE";
@@ -91,7 +91,7 @@ export function loadBrokerSession(cwd) {
 export function saveBrokerSession(cwd, session) {
   const stateDir = resolveStateDir(cwd);
   fs.mkdirSync(stateDir, { recursive: true });
-  fs.writeFileSync(resolveBrokerStateFile(cwd), `${JSON.stringify(session, null, 2)}\n`, "utf8");
+  writeJsonFileAtomic(resolveBrokerStateFile(cwd), session);
 }
 
 export function clearBrokerSession(cwd) {
@@ -113,63 +113,65 @@ async function isBrokerEndpointReady(endpoint) {
 }
 
 export async function ensureBrokerSession(cwd, options = {}) {
-  const existing = loadBrokerSession(cwd);
-  if (existing && (await isBrokerEndpointReady(existing.endpoint))) {
-    return existing;
-  }
+  return withStateLockAsync(cwd, async () => {
+    const existing = loadBrokerSession(cwd);
+    if (existing && (await isBrokerEndpointReady(existing.endpoint))) {
+      return existing;
+    }
 
-  if (existing) {
-    teardownBrokerSession({
-      endpoint: existing.endpoint ?? null,
-      pidFile: existing.pidFile ?? null,
-      logFile: existing.logFile ?? null,
-      sessionDir: existing.sessionDir ?? null,
-      pid: existing.pid ?? null,
-      killProcess: options.killProcess ?? null
+    if (existing) {
+      teardownBrokerSession({
+        endpoint: existing.endpoint ?? null,
+        pidFile: existing.pidFile ?? null,
+        logFile: existing.logFile ?? null,
+        sessionDir: existing.sessionDir ?? null,
+        pid: existing.pid ?? null,
+        killProcess: options.killProcess ?? null
+      });
+      clearBrokerSession(cwd);
+    }
+
+    const sessionDir = createBrokerSessionDir();
+    const endpointFactory = options.createBrokerEndpoint ?? createBrokerEndpoint;
+    const endpoint = endpointFactory(sessionDir, options.platform);
+    const pidFile = path.join(sessionDir, "broker.pid");
+    const logFile = path.join(sessionDir, "broker.log");
+    const scriptPath =
+      options.scriptPath ??
+      fileURLToPath(new URL("../app-server-broker.mjs", import.meta.url));
+
+    const child = spawnBrokerProcess({
+      scriptPath,
+      cwd,
+      endpoint,
+      pidFile,
+      logFile,
+      env: options.env ?? process.env
     });
-    clearBrokerSession(cwd);
-  }
 
-  const sessionDir = createBrokerSessionDir();
-  const endpointFactory = options.createBrokerEndpoint ?? createBrokerEndpoint;
-  const endpoint = endpointFactory(sessionDir, options.platform);
-  const pidFile = path.join(sessionDir, "broker.pid");
-  const logFile = path.join(sessionDir, "broker.log");
-  const scriptPath =
-    options.scriptPath ??
-    fileURLToPath(new URL("../app-server-broker.mjs", import.meta.url));
+    const ready = await waitForBrokerEndpoint(endpoint, options.timeoutMs ?? 2000);
+    if (!ready) {
+      teardownBrokerSession({
+        endpoint,
+        pidFile,
+        logFile,
+        sessionDir,
+        pid: child.pid ?? null,
+        killProcess: options.killProcess ?? null
+      });
+      return null;
+    }
 
-  const child = spawnBrokerProcess({
-    scriptPath,
-    cwd,
-    endpoint,
-    pidFile,
-    logFile,
-    env: options.env ?? process.env
-  });
-
-  const ready = await waitForBrokerEndpoint(endpoint, options.timeoutMs ?? 2000);
-  if (!ready) {
-    teardownBrokerSession({
+    const session = {
       endpoint,
       pidFile,
       logFile,
       sessionDir,
-      pid: child.pid ?? null,
-      killProcess: options.killProcess ?? null
-    });
-    return null;
-  }
-
-  const session = {
-    endpoint,
-    pidFile,
-    logFile,
-    sessionDir,
-    pid: child.pid ?? null
-  };
-  saveBrokerSession(cwd, session);
-  return session;
+      pid: child.pid ?? null
+    };
+    saveBrokerSession(cwd, session);
+    return session;
+  });
 }
 
 export function teardownBrokerSession({ endpoint = null, pidFile, logFile, sessionDir = null, pid = null, killProcess = null }) {

--- a/scripts/crew-codex/lib/codex.mjs
+++ b/scripts/crew-codex/lib/codex.mjs
@@ -1,0 +1,1090 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+/**
+ * @typedef {import("./app-server-protocol").AppServerNotification} AppServerNotification
+ * @typedef {import("./app-server-protocol").ReviewTarget} ReviewTarget
+ * @typedef {import("./app-server-protocol").ThreadItem} ThreadItem
+ * @typedef {import("./app-server-protocol").ThreadResumeParams} ThreadResumeParams
+ * @typedef {import("./app-server-protocol").ThreadStartParams} ThreadStartParams
+ * @typedef {import("./app-server-protocol").Turn} Turn
+ * @typedef {import("./app-server-protocol").UserInput} UserInput
+ * @typedef {((update: string | { message: string, phase: string | null, threadId?: string | null, turnId?: string | null, stderrMessage?: string | null, logTitle?: string | null, logBody?: string | null }) => void)} ProgressReporter
+ * @typedef {{
+ *   threadId: string,
+ *   rootThreadId: string,
+ *   threadIds: Set<string>,
+ *   threadTurnIds: Map<string, string>,
+ *   threadLabels: Map<string, string>,
+ *   turnId: string | null,
+ *   bufferedNotifications: AppServerNotification[],
+ *   completion: Promise<TurnCaptureState>,
+ *   resolveCompletion: (state: TurnCaptureState) => void,
+ *   rejectCompletion: (error: unknown) => void,
+ *   finalTurn: Turn | null,
+ *   completed: boolean,
+ *   finalAnswerSeen: boolean,
+ *   pendingCollaborations: Set<string>,
+ *   activeSubagentTurns: Set<string>,
+ *   completionTimer: ReturnType<typeof setTimeout> | null,
+ *   lastAgentMessage: string,
+ *   reviewText: string,
+ *   reasoningSummary: string[],
+ *   error: unknown,
+ *   messages: Array<{ lifecycle: string, phase: string | null, text: string }>,
+ *   fileChanges: ThreadItem[],
+ *   commandExecutions: ThreadItem[],
+ *   onProgress: ProgressReporter | null
+ * }} TurnCaptureState
+ */
+import { readJsonFile } from "./fs.mjs";
+import { BROKER_BUSY_RPC_CODE, BROKER_ENDPOINT_ENV, CodexAppServerClient } from "./app-server.mjs";
+import { loadBrokerSession } from "./broker-lifecycle.mjs";
+import { binaryAvailable } from "./process.mjs";
+
+const SERVICE_NAME = "claude_code_codex_plugin";
+const TASK_THREAD_PREFIX = "Codex Companion Task";
+const DEFAULT_CONTINUE_PROMPT =
+  "Continue from the current thread state. Pick the next highest-value step and follow through until the task is resolved.";
+
+function cleanCodexStderr(stderr) {
+  return stderr
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line && !line.startsWith("WARNING: proceeding, even though we could not update PATH:"))
+    .join("\n");
+}
+
+/** @returns {ThreadStartParams} */
+function buildThreadParams(cwd, options = {}) {
+  return {
+    cwd,
+    model: options.model ?? null,
+    approvalPolicy: options.approvalPolicy ?? "never",
+    sandbox: options.sandbox ?? "read-only",
+    serviceName: SERVICE_NAME,
+    ephemeral: options.ephemeral ?? true,
+    experimentalRawEvents: false
+  };
+}
+
+/** @returns {ThreadResumeParams} */
+function buildResumeParams(threadId, cwd, options = {}) {
+  return {
+    threadId,
+    cwd,
+    model: options.model ?? null,
+    approvalPolicy: options.approvalPolicy ?? "never",
+    sandbox: options.sandbox ?? "read-only"
+  };
+}
+
+/** @returns {UserInput[]} */
+function buildTurnInput(prompt) {
+  return [{ type: "text", text: prompt, text_elements: [] }];
+}
+
+function shorten(text, limit = 72) {
+  const normalized = String(text ?? "").trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  return `${normalized.slice(0, limit - 3)}...`;
+}
+
+function looksLikeVerificationCommand(command) {
+  return /\b(test|tests|lint|build|typecheck|type-check|check|verify|validate|pytest|jest|vitest|cargo test|npm test|pnpm test|yarn test|go test|mvn test|gradle test|tsc|eslint|ruff)\b/i.test(
+    command
+  );
+}
+
+function buildTaskThreadName(prompt) {
+  const excerpt = shorten(prompt, 56);
+  return excerpt ? `${TASK_THREAD_PREFIX}: ${excerpt}` : TASK_THREAD_PREFIX;
+}
+
+function extractThreadId(message) {
+  return message?.params?.threadId ?? null;
+}
+
+function extractTurnId(message) {
+  if (message?.params?.turnId) {
+    return message.params.turnId;
+  }
+  if (message?.params?.turn?.id) {
+    return message.params.turn.id;
+  }
+  return null;
+}
+
+function collectTouchedFiles(fileChanges) {
+  const paths = new Set();
+  for (const fileChange of fileChanges) {
+    for (const change of fileChange.changes ?? []) {
+      if (change.path) {
+        paths.add(change.path);
+      }
+    }
+  }
+  return [...paths];
+}
+
+function normalizeReasoningText(text) {
+  return String(text ?? "").replace(/\s+/g, " ").trim();
+}
+
+function extractReasoningSections(value) {
+  if (!value) {
+    return [];
+  }
+
+  if (typeof value === "string") {
+    const normalized = normalizeReasoningText(value);
+    return normalized ? [normalized] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractReasoningSections(entry));
+  }
+
+  if (typeof value === "object") {
+    if (typeof value.text === "string") {
+      return extractReasoningSections(value.text);
+    }
+    if ("summary" in value) {
+      return extractReasoningSections(value.summary);
+    }
+    if ("content" in value) {
+      return extractReasoningSections(value.content);
+    }
+    if ("parts" in value) {
+      return extractReasoningSections(value.parts);
+    }
+  }
+
+  return [];
+}
+
+function mergeReasoningSections(existingSections, nextSections) {
+  const merged = [];
+  for (const section of [...existingSections, ...nextSections]) {
+    const normalized = normalizeReasoningText(section);
+    if (!normalized || merged.includes(normalized)) {
+      continue;
+    }
+    merged.push(normalized);
+  }
+  return merged;
+}
+
+/**
+ * @param {ProgressReporter | null | undefined} onProgress
+ * @param {string | null | undefined} message
+ * @param {string | null | undefined} [phase]
+ */
+function emitProgress(onProgress, message, phase = null, extra = {}) {
+  if (!onProgress || !message) {
+    return;
+  }
+  if (!phase && Object.keys(extra).length === 0) {
+    onProgress(message);
+    return;
+  }
+  onProgress({ message, phase, ...extra });
+}
+
+function emitLogEvent(onProgress, options = {}) {
+  if (!onProgress) {
+    return;
+  }
+
+  onProgress({
+    message: options.message ?? "",
+    phase: options.phase ?? null,
+    stderrMessage: options.stderrMessage ?? null,
+    logTitle: options.logTitle ?? null,
+    logBody: options.logBody ?? null
+  });
+}
+
+function labelForThread(state, threadId) {
+  if (!threadId || threadId === state.rootThreadId || threadId === state.threadId) {
+    return null;
+  }
+  return state.threadLabels.get(threadId) ?? threadId;
+}
+
+function registerThread(state, threadId, options = {}) {
+  if (!threadId) {
+    return;
+  }
+
+  state.threadIds.add(threadId);
+  const label =
+    options.threadName ??
+    options.name ??
+    options.agentNickname ??
+    options.agentRole ??
+    state.threadLabels.get(threadId) ??
+    null;
+  if (label) {
+    state.threadLabels.set(threadId, label);
+  }
+}
+
+function describeStartedItem(state, item) {
+  switch (item.type) {
+    case "enteredReviewMode":
+      return { message: `Reviewer started: ${item.review}`, phase: "reviewing" };
+    case "commandExecution":
+      return {
+        message: `Running command: ${shorten(item.command, 96)}`,
+        phase: looksLikeVerificationCommand(item.command) ? "verifying" : "running"
+      };
+    case "fileChange":
+      return { message: `Applying ${item.changes.length} file change(s).`, phase: "editing" };
+    case "mcpToolCall":
+      return { message: `Calling ${item.server}/${item.tool}.`, phase: "investigating" };
+    case "dynamicToolCall":
+      return { message: `Running tool: ${item.tool}.`, phase: "investigating" };
+    case "collabAgentToolCall": {
+      const subagents = (item.receiverThreadIds ?? []).map((threadId) => labelForThread(state, threadId) ?? threadId);
+      const summary =
+        subagents.length > 0
+          ? `Starting subagent ${subagents.join(", ")} via collaboration tool: ${item.tool}.`
+          : `Starting collaboration tool: ${item.tool}.`;
+      return { message: summary, phase: "investigating" };
+    }
+    case "webSearch":
+      return { message: `Searching: ${shorten(item.query, 96)}`, phase: "investigating" };
+    default:
+      return null;
+  }
+}
+
+function describeCompletedItem(state, item) {
+  switch (item.type) {
+    case "commandExecution": {
+      const exitCode = item.exitCode ?? "?";
+      const statusLabel = item.status === "completed" ? "completed" : item.status;
+      return {
+        message: `Command ${statusLabel}: ${shorten(item.command, 96)} (exit ${exitCode})`,
+        phase: looksLikeVerificationCommand(item.command) ? "verifying" : "running"
+      };
+    }
+    case "fileChange":
+      return { message: `File changes ${item.status}.`, phase: "editing" };
+    case "mcpToolCall":
+      return { message: `Tool ${item.server}/${item.tool} ${item.status}.`, phase: "investigating" };
+    case "dynamicToolCall":
+      return { message: `Tool ${item.tool} ${item.status}.`, phase: "investigating" };
+    case "collabAgentToolCall": {
+      const subagents = (item.receiverThreadIds ?? []).map((threadId) => labelForThread(state, threadId) ?? threadId);
+      const summary =
+        subagents.length > 0
+          ? `Subagent ${subagents.join(", ")} ${item.status}.`
+          : `Collaboration tool ${item.tool} ${item.status}.`;
+      return { message: summary, phase: "investigating" };
+    }
+    case "exitedReviewMode":
+      return { message: "Reviewer finished.", phase: "finalizing" };
+    default:
+      return null;
+  }
+}
+
+/** @returns {TurnCaptureState} */
+function createTurnCaptureState(threadId, options = {}) {
+  let resolveCompletion;
+  let rejectCompletion;
+  const completion = new Promise((resolve, reject) => {
+    resolveCompletion = resolve;
+    rejectCompletion = reject;
+  });
+
+  return {
+    threadId,
+    rootThreadId: threadId,
+    threadIds: new Set([threadId]),
+    threadTurnIds: new Map(),
+    threadLabels: new Map(),
+    turnId: null,
+    bufferedNotifications: [],
+    completion,
+    resolveCompletion,
+    rejectCompletion,
+    finalTurn: null,
+    completed: false,
+    finalAnswerSeen: false,
+    pendingCollaborations: new Set(),
+    activeSubagentTurns: new Set(),
+    completionTimer: null,
+    lastAgentMessage: "",
+    reviewText: "",
+    reasoningSummary: [],
+    error: null,
+    messages: [],
+    fileChanges: [],
+    commandExecutions: [],
+    onProgress: options.onProgress ?? null
+  };
+}
+
+function clearCompletionTimer(state) {
+  if (state.completionTimer) {
+    clearTimeout(state.completionTimer);
+    state.completionTimer = null;
+  }
+}
+
+function completeTurn(state, turn = null, options = {}) {
+  if (state.completed) {
+    return;
+  }
+
+  clearCompletionTimer(state);
+  state.completed = true;
+
+  if (turn) {
+    state.finalTurn = turn;
+    if (!state.turnId) {
+      state.turnId = turn.id;
+    }
+  } else if (!state.finalTurn) {
+    state.finalTurn = {
+      id: state.turnId ?? "inferred-turn",
+      status: "completed"
+    };
+  }
+
+  if (options.inferred) {
+    emitProgress(state.onProgress, "Turn completion inferred after the main thread finished and subagent work drained.", "finalizing");
+  }
+
+  state.resolveCompletion(state);
+}
+
+function scheduleInferredCompletion(state) {
+  if (state.completed || state.finalTurn || !state.finalAnswerSeen) {
+    return;
+  }
+
+  if (state.pendingCollaborations.size > 0 || state.activeSubagentTurns.size > 0) {
+    return;
+  }
+
+  clearCompletionTimer(state);
+  state.completionTimer = setTimeout(() => {
+    state.completionTimer = null;
+    if (state.completed || state.finalTurn || !state.finalAnswerSeen) {
+      return;
+    }
+    if (state.pendingCollaborations.size > 0 || state.activeSubagentTurns.size > 0) {
+      return;
+    }
+    completeTurn(state, null, { inferred: true });
+  }, 250);
+  state.completionTimer.unref?.();
+}
+
+function belongsToTurn(state, message) {
+  const messageThreadId = extractThreadId(message);
+  if (!messageThreadId || !state.threadIds.has(messageThreadId)) {
+    return false;
+  }
+  const trackedTurnId = state.threadTurnIds.get(messageThreadId) ?? null;
+  const messageTurnId = extractTurnId(message);
+  return trackedTurnId === null || messageTurnId === null || messageTurnId === trackedTurnId;
+}
+
+function recordItem(state, item, lifecycle, threadId = null) {
+  if (item.type === "collabAgentToolCall") {
+    if (!threadId || threadId === state.threadId) {
+      if (lifecycle === "started" || item.status === "inProgress") {
+        state.pendingCollaborations.add(item.id);
+      } else if (lifecycle === "completed") {
+        state.pendingCollaborations.delete(item.id);
+        scheduleInferredCompletion(state);
+      }
+    }
+    for (const receiverThreadId of item.receiverThreadIds ?? []) {
+      registerThread(state, receiverThreadId);
+    }
+  }
+
+  if (item.type === "agentMessage") {
+    state.messages.push({
+      lifecycle,
+      phase: item.phase ?? null,
+      text: item.text ?? ""
+    });
+    if (item.text) {
+      if (!threadId || threadId === state.threadId) {
+        state.lastAgentMessage = item.text;
+        if (lifecycle === "completed" && item.phase === "final_answer") {
+          state.finalAnswerSeen = true;
+          scheduleInferredCompletion(state);
+        }
+      }
+      if (lifecycle === "completed") {
+        const sourceLabel = labelForThread(state, threadId);
+        emitLogEvent(state.onProgress, {
+          message: sourceLabel ? `Subagent ${sourceLabel}: ${shorten(item.text, 96)}` : `Assistant message captured: ${shorten(item.text, 96)}`,
+          stderrMessage: null,
+          phase: item.phase === "final_answer" ? "finalizing" : null,
+          logTitle: sourceLabel ? `Subagent ${sourceLabel} message` : "Assistant message",
+          logBody: item.text
+        });
+      }
+    }
+    return;
+  }
+
+  if (item.type === "exitedReviewMode") {
+    state.reviewText = item.review ?? "";
+    if (lifecycle === "completed" && item.review) {
+      emitLogEvent(state.onProgress, {
+        message: "Review output captured.",
+        stderrMessage: null,
+        phase: "finalizing",
+        logTitle: "Review output",
+        logBody: item.review
+      });
+    }
+    return;
+  }
+
+  if (item.type === "reasoning" && lifecycle === "completed") {
+    const nextSections = extractReasoningSections(item.summary);
+    state.reasoningSummary = mergeReasoningSections(state.reasoningSummary, nextSections);
+    if (nextSections.length > 0) {
+      const sourceLabel = labelForThread(state, threadId);
+      emitLogEvent(state.onProgress, {
+        message: sourceLabel
+          ? `Subagent ${sourceLabel} reasoning: ${shorten(nextSections[0], 96)}`
+          : `Reasoning summary captured: ${shorten(nextSections[0], 96)}`,
+        stderrMessage: null,
+        logTitle: sourceLabel ? `Subagent ${sourceLabel} reasoning summary` : "Reasoning summary",
+        logBody: nextSections.map((section) => `- ${section}`).join("\n")
+      });
+    }
+    return;
+  }
+
+  if (item.type === "fileChange" && lifecycle === "completed") {
+    state.fileChanges.push(item);
+    return;
+  }
+
+  if (item.type === "commandExecution" && lifecycle === "completed") {
+    state.commandExecutions.push(item);
+  }
+}
+
+function applyTurnNotification(state, message) {
+  switch (message.method) {
+    case "thread/started":
+      registerThread(state, message.params.thread.id, {
+        threadName: message.params.thread.name,
+        name: message.params.thread.name,
+        agentNickname: message.params.thread.agentNickname,
+        agentRole: message.params.thread.agentRole
+      });
+      break;
+    case "thread/name/updated":
+      registerThread(state, message.params.threadId, {
+        threadName: message.params.threadName ?? null
+      });
+      break;
+    case "turn/started":
+      registerThread(state, message.params.threadId);
+      state.threadTurnIds.set(message.params.threadId, message.params.turn.id);
+      if ((message.params.threadId ?? null) !== state.threadId) {
+        state.activeSubagentTurns.add(message.params.threadId);
+      }
+      emitProgress(
+        state.onProgress,
+        `Turn started (${message.params.turn.id}).`,
+        "starting",
+        (message.params.threadId ?? null) === state.threadId
+          ? {
+              threadId: message.params.threadId ?? null,
+              turnId: message.params.turn.id ?? null
+            }
+          : {}
+      );
+      break;
+    case "item/started":
+      recordItem(state, message.params.item, "started", message.params.threadId ?? null);
+      {
+        const update = describeStartedItem(state, message.params.item);
+        emitProgress(state.onProgress, update?.message, update?.phase ?? null);
+      }
+      break;
+    case "item/completed":
+      recordItem(state, message.params.item, "completed", message.params.threadId ?? null);
+      {
+        const update = describeCompletedItem(state, message.params.item);
+        emitProgress(state.onProgress, update?.message, update?.phase ?? null);
+      }
+      break;
+    case "error":
+      state.error = message.params.error;
+      emitProgress(state.onProgress, `Codex error: ${message.params.error.message}`, "failed");
+      break;
+    case "turn/completed":
+      if ((message.params.threadId ?? null) !== state.threadId) {
+        state.activeSubagentTurns.delete(message.params.threadId);
+        scheduleInferredCompletion(state);
+        break;
+      }
+      emitProgress(
+        state.onProgress,
+        `Turn ${message.params.turn.status === "completed" ? "completed" : message.params.turn.status}.`,
+        "finalizing"
+      );
+      completeTurn(state, message.params.turn);
+      break;
+    default:
+      break;
+  }
+}
+
+async function captureTurn(client, threadId, startRequest, options = {}) {
+  const state = createTurnCaptureState(threadId, options);
+  const previousHandler = client.notificationHandler;
+
+  client.setNotificationHandler((message) => {
+    if (!state.turnId) {
+      state.bufferedNotifications.push(message);
+      return;
+    }
+
+    if (message.method === "thread/started" || message.method === "thread/name/updated") {
+      applyTurnNotification(state, message);
+      return;
+    }
+
+    if (!belongsToTurn(state, message)) {
+        if (previousHandler) {
+          previousHandler(message);
+        }
+        return;
+    }
+
+    applyTurnNotification(state, message);
+  });
+
+  try {
+    const response = await startRequest();
+    options.onResponse?.(response, state);
+    state.turnId = response.turn?.id ?? null;
+    if (state.turnId) {
+      state.threadTurnIds.set(state.threadId, state.turnId);
+    }
+    for (const message of state.bufferedNotifications) {
+      if (belongsToTurn(state, message)) {
+        applyTurnNotification(state, message);
+      } else {
+        if (previousHandler) {
+          previousHandler(message);
+        }
+      }
+    }
+    state.bufferedNotifications.length = 0;
+
+    if (response.turn?.status && response.turn.status !== "inProgress") {
+      completeTurn(state, response.turn);
+    }
+
+    return await state.completion;
+  } finally {
+    clearCompletionTimer(state);
+    client.setNotificationHandler(previousHandler ?? null);
+  }
+}
+
+async function withAppServer(cwd, fn) {
+  let client = null;
+  try {
+    client = await CodexAppServerClient.connect(cwd);
+    const result = await fn(client);
+    await client.close();
+    return result;
+  } catch (error) {
+    const brokerRequested = client?.transport === "broker" || Boolean(process.env[BROKER_ENDPOINT_ENV]);
+    const shouldRetryDirect =
+      (client?.transport === "broker" && error?.rpcCode === BROKER_BUSY_RPC_CODE) ||
+      (brokerRequested && (error?.code === "ENOENT" || error?.code === "ECONNREFUSED"));
+
+    if (client) {
+      await client.close().catch(() => {});
+      client = null;
+    }
+
+    if (!shouldRetryDirect) {
+      throw error;
+    }
+
+    const directClient = await CodexAppServerClient.connect(cwd, { disableBroker: true });
+    try {
+      return await fn(directClient);
+    } finally {
+      await directClient.close();
+    }
+  }
+}
+
+async function startThread(client, cwd, options = {}) {
+  const response = await client.request("thread/start", buildThreadParams(cwd, options));
+  const threadId = response.thread.id;
+  if (options.threadName) {
+    try {
+      await client.request("thread/name/set", { threadId, name: options.threadName });
+    } catch (err) {
+      // Only suppress "unknown variant/method" errors from older CLI versions
+      // that don't support thread/name/set. Rethrow auth, network, or server errors.
+      const msg = String(err?.message ?? err ?? "");
+      if (!msg.includes("unknown variant") && !msg.includes("unknown method")) {
+        throw err;
+      }
+    }
+  }
+  return response;
+}
+
+async function resumeThread(client, threadId, cwd, options = {}) {
+  return client.request("thread/resume", buildResumeParams(threadId, cwd, options));
+}
+
+function buildResultStatus(turnState) {
+  return turnState.finalTurn?.status === "completed" ? 0 : 1;
+}
+
+const BUILTIN_PROVIDER_LABELS = new Map([
+  ["openai", "OpenAI"],
+  ["ollama", "Ollama"],
+  ["lmstudio", "LM Studio"]
+]);
+
+function normalizeProviderId(value) {
+  const providerId = typeof value === "string" ? value.trim() : "";
+  return providerId || null;
+}
+
+function formatProviderLabel(providerId, providerConfig = null) {
+  const configuredName = typeof providerConfig?.name === "string" ? providerConfig.name.trim() : "";
+  if (configuredName) {
+    return configuredName;
+  }
+  if (!providerId) {
+    return "The active provider";
+  }
+  return BUILTIN_PROVIDER_LABELS.get(providerId) ?? providerId;
+}
+
+function buildAuthStatus(fields = {}) {
+  return {
+    available: true,
+    loggedIn: false,
+    detail: "not authenticated",
+    source: "unknown",
+    authMethod: null,
+    verified: null,
+    requiresOpenaiAuth: null,
+    provider: null,
+    ...fields
+  };
+}
+
+function resolveProviderConfig(configResponse) {
+  const config = configResponse?.config;
+  if (!config || typeof config !== "object") {
+    return {
+      providerId: null,
+      providerConfig: null
+    };
+  }
+
+  const providerId = normalizeProviderId(config.model_provider);
+  const providers =
+    config.model_providers && typeof config.model_providers === "object" && !Array.isArray(config.model_providers)
+      ? config.model_providers
+      : null;
+  const providerConfig =
+    providerId && providers?.[providerId] && typeof providers[providerId] === "object" ? providers[providerId] : null;
+
+  return {
+    providerId,
+    providerConfig
+  };
+}
+
+function buildAppServerAuthStatus(accountResponse, configResponse) {
+  const account = accountResponse?.account ?? null;
+  const requiresOpenaiAuth =
+    typeof accountResponse?.requiresOpenaiAuth === "boolean" ? accountResponse.requiresOpenaiAuth : null;
+  const { providerId, providerConfig } = resolveProviderConfig(configResponse);
+  const providerLabel = formatProviderLabel(providerId, providerConfig);
+
+  if (account?.type === "chatgpt") {
+    const email = typeof account.email === "string" && account.email.trim() ? account.email.trim() : null;
+    return buildAuthStatus({
+      loggedIn: true,
+      detail: email ? `ChatGPT login active for ${email}` : "ChatGPT login active",
+      source: "app-server",
+      authMethod: "chatgpt",
+      verified: true,
+      requiresOpenaiAuth,
+      provider: providerId
+    });
+  }
+
+  if (account?.type === "apiKey") {
+    return buildAuthStatus({
+      loggedIn: true,
+      detail: "API key configured (unverified)",
+      source: "app-server",
+      authMethod: "apiKey",
+      verified: false,
+      requiresOpenaiAuth,
+      provider: providerId
+    });
+  }
+
+  if (requiresOpenaiAuth === false) {
+    return buildAuthStatus({
+      loggedIn: true,
+      detail: `${providerLabel} is configured and does not require OpenAI authentication`,
+      source: "app-server",
+      requiresOpenaiAuth,
+      provider: providerId
+    });
+  }
+
+  return buildAuthStatus({
+    loggedIn: false,
+    detail: `${providerLabel} requires OpenAI authentication`,
+    source: "app-server",
+    requiresOpenaiAuth,
+    provider: providerId
+  });
+}
+
+async function getCodexAuthStatusFromClient(client, cwd) {
+  try {
+    const accountResponse = await client.request("account/read", { refreshToken: false });
+    const configResponse = await client.request("config/read", {
+      includeLayers: false,
+      cwd
+    });
+
+    return buildAppServerAuthStatus(accountResponse, configResponse);
+  } catch (error) {
+    return buildAuthStatus({
+      loggedIn: false,
+      detail: error instanceof Error ? error.message : String(error),
+      source: "app-server"
+    });
+  }
+}
+
+export function getCodexAvailability(cwd) {
+  const versionStatus = binaryAvailable("codex", ["--version"], { cwd });
+  if (!versionStatus.available) {
+    return versionStatus;
+  }
+
+  const appServerStatus = binaryAvailable("codex", ["app-server", "--help"], { cwd });
+  if (!appServerStatus.available) {
+    return {
+      available: false,
+      detail: `${versionStatus.detail}; advanced runtime unavailable: ${appServerStatus.detail}`
+    };
+  }
+
+  return {
+    available: true,
+    detail: `${versionStatus.detail}; advanced runtime available`
+  };
+}
+
+export function getSessionRuntimeStatus(env = process.env, cwd = process.cwd()) {
+  const endpoint = env?.[BROKER_ENDPOINT_ENV] ?? loadBrokerSession(cwd)?.endpoint ?? null;
+  if (endpoint) {
+    return {
+      mode: "shared",
+      label: "shared session",
+      detail: "This Claude session is configured to reuse one shared Codex runtime.",
+      endpoint
+    };
+  }
+
+  return {
+    mode: "direct",
+    label: "direct startup",
+    detail: "No shared Codex runtime is active yet. The first review or task command will start one on demand.",
+    endpoint: null
+  };
+}
+
+export async function getCodexAuthStatus(cwd, options = {}) {
+  const availability = getCodexAvailability(cwd);
+  if (!availability.available) {
+    return {
+      available: false,
+      loggedIn: false,
+      detail: availability.detail,
+      source: "availability",
+      authMethod: null,
+      verified: null,
+      requiresOpenaiAuth: null,
+      provider: null
+    };
+  }
+
+  let client = null;
+  try {
+    client = await CodexAppServerClient.connect(cwd, {
+      env: options.env,
+      reuseExistingBroker: true
+    });
+    return await getCodexAuthStatusFromClient(client, cwd);
+  } catch (error) {
+    return buildAuthStatus({
+      loggedIn: false,
+      detail: error instanceof Error ? error.message : String(error),
+      source: "app-server"
+    });
+  } finally {
+    if (client) {
+      await client.close().catch(() => {});
+    }
+  }
+}
+
+export async function interruptAppServerTurn(cwd, { threadId, turnId }) {
+  if (!threadId || !turnId) {
+    return {
+      attempted: false,
+      interrupted: false,
+      transport: null,
+      detail: "missing threadId or turnId"
+    };
+  }
+
+  const availability = getCodexAvailability(cwd);
+  if (!availability.available) {
+    return {
+      attempted: false,
+      interrupted: false,
+      transport: null,
+      detail: availability.detail
+    };
+  }
+
+  let client = null;
+  try {
+    client = await CodexAppServerClient.connect(cwd, { reuseExistingBroker: true });
+    await client.request("turn/interrupt", { threadId, turnId });
+    return {
+      attempted: true,
+      interrupted: true,
+      transport: client.transport,
+      detail: `Interrupted ${turnId} on ${threadId}.`
+    };
+  } catch (error) {
+    return {
+      attempted: true,
+      interrupted: false,
+      transport: client?.transport ?? null,
+      detail: error instanceof Error ? error.message : String(error)
+    };
+  } finally {
+    await client?.close().catch(() => {});
+  }
+}
+
+export async function runAppServerReview(cwd, options = {}) {
+  const availability = getCodexAvailability(cwd);
+  if (!availability.available) {
+    throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/crew-setup`.");
+  }
+
+  return withAppServer(cwd, async (client) => {
+    emitProgress(options.onProgress, "Starting Codex review thread.", "starting");
+    const thread = await startThread(client, cwd, {
+      model: options.model,
+      sandbox: "read-only",
+      ephemeral: true,
+      threadName: options.threadName
+    });
+    const sourceThreadId = thread.thread.id;
+    emitProgress(options.onProgress, `Thread ready (${sourceThreadId}).`, "starting", {
+      threadId: sourceThreadId
+    });
+    const delivery = options.delivery ?? "inline";
+
+    const turnState = await captureTurn(
+      client,
+      sourceThreadId,
+      () =>
+        client.request("review/start", {
+          threadId: sourceThreadId,
+          delivery,
+          target: options.target
+        }),
+      {
+        onProgress: options.onProgress,
+        onResponse(response, state) {
+          if (response.reviewThreadId) {
+            state.threadIds.add(response.reviewThreadId);
+            if (delivery === "detached") {
+              state.threadId = response.reviewThreadId;
+            }
+          }
+        }
+      }
+    );
+
+    return {
+      status: buildResultStatus(turnState),
+      threadId: turnState.threadId,
+      sourceThreadId,
+      turnId: turnState.turnId,
+      reviewText: turnState.reviewText,
+      reasoningSummary: turnState.reasoningSummary,
+      turn: turnState.finalTurn,
+      error: turnState.error,
+      stderr: cleanCodexStderr(client.stderr)
+    };
+  });
+}
+
+export async function runAppServerTurn(cwd, options = {}) {
+  const availability = getCodexAvailability(cwd);
+  if (!availability.available) {
+    throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/crew-setup`.");
+  }
+
+  return withAppServer(cwd, async (client) => {
+    let threadId;
+
+    if (options.resumeThreadId) {
+      emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
+      const response = await resumeThread(client, options.resumeThreadId, cwd, {
+        model: options.model,
+        sandbox: options.sandbox,
+        ephemeral: false
+      });
+      threadId = response.thread.id;
+    } else {
+      emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
+      const response = await startThread(client, cwd, {
+        model: options.model,
+        sandbox: options.sandbox,
+        ephemeral: options.persistThread ? false : true,
+        threadName: options.persistThread ? options.threadName : options.threadName ?? null
+      });
+      threadId = response.thread.id;
+    }
+
+    emitProgress(options.onProgress, `Thread ready (${threadId}).`, "starting", {
+      threadId
+    });
+
+    const prompt = options.prompt?.trim() || options.defaultPrompt || "";
+    if (!prompt) {
+      throw new Error("A prompt is required for this Codex run.");
+    }
+
+    const turnState = await captureTurn(
+      client,
+      threadId,
+      () =>
+        client.request("turn/start", {
+          threadId,
+          input: buildTurnInput(prompt),
+          model: options.model ?? null,
+          effort: options.effort ?? null,
+          outputSchema: options.outputSchema ?? null
+        }),
+      { onProgress: options.onProgress }
+    );
+
+    return {
+      status: buildResultStatus(turnState),
+      threadId,
+      turnId: turnState.turnId,
+      finalMessage: turnState.lastAgentMessage,
+      reasoningSummary: turnState.reasoningSummary,
+      turn: turnState.finalTurn,
+      error: turnState.error,
+      stderr: cleanCodexStderr(client.stderr),
+      fileChanges: turnState.fileChanges,
+      touchedFiles: collectTouchedFiles(turnState.fileChanges),
+      commandExecutions: turnState.commandExecutions
+    };
+  });
+}
+
+export async function findLatestTaskThread(cwd) {
+  const availability = getCodexAvailability(cwd);
+  if (!availability.available) {
+    throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/crew-setup`.");
+  }
+
+  return withAppServer(cwd, async (client) => {
+    const response = await client.request("thread/list", {
+      cwd,
+      limit: 20,
+      sortKey: "updated_at",
+      sourceKinds: ["appServer"],
+      searchTerm: TASK_THREAD_PREFIX
+    });
+
+    return (
+      response.data.find((thread) => typeof thread.name === "string" && thread.name.startsWith(TASK_THREAD_PREFIX)) ??
+      null
+    );
+  });
+}
+
+export function buildPersistentTaskThreadName(prompt) {
+  return buildTaskThreadName(prompt);
+}
+
+export function parseStructuredOutput(rawOutput, fallback = {}) {
+  if (!rawOutput) {
+    return {
+      parsed: null,
+      parseError: fallback.failureMessage ?? "Codex did not return a final structured message.",
+      rawOutput: rawOutput ?? "",
+      ...fallback
+    };
+  }
+
+  try {
+    return {
+      parsed: JSON.parse(rawOutput),
+      parseError: null,
+      rawOutput,
+      ...fallback
+    };
+  } catch (error) {
+    return {
+      parsed: null,
+      parseError: error.message,
+      rawOutput,
+      ...fallback
+    };
+  }
+}
+
+export function readOutputSchema(schemaPath) {
+  return readJsonFile(schemaPath);
+}
+
+export { DEFAULT_CONTINUE_PROMPT, TASK_THREAD_PREFIX };

--- a/scripts/crew-codex/lib/fs.mjs
+++ b/scripts/crew-codex/lib/fs.mjs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export function ensureAbsolutePath(cwd, maybePath) {
+  return path.isAbsolute(maybePath) ? maybePath : path.resolve(cwd, maybePath);
+}
+
+export function createTempDir(prefix = "codex-plugin-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+export function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+export function writeJsonFile(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export function safeReadFile(filePath) {
+  return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "";
+}
+
+export function isProbablyText(buffer) {
+  const sample = buffer.subarray(0, Math.min(buffer.length, 4096));
+  for (const value of sample) {
+    if (value === 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function readStdinIfPiped() {
+  if (process.stdin.isTTY) {
+    return "";
+  }
+  return fs.readFileSync(0, "utf8");
+}

--- a/scripts/crew-codex/lib/git.mjs
+++ b/scripts/crew-codex/lib/git.mjs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import fs from "node:fs";
+import path from "node:path";
+
+import { isProbablyText } from "./fs.mjs";
+import { formatCommandFailure, runCommand, runCommandChecked } from "./process.mjs";
+
+const MAX_UNTRACKED_BYTES = 24 * 1024;
+const DEFAULT_INLINE_DIFF_MAX_FILES = 2;
+const DEFAULT_INLINE_DIFF_MAX_BYTES = 256 * 1024;
+
+function git(cwd, args, options = {}) {
+  return runCommand("git", args, { cwd, ...options });
+}
+
+function gitChecked(cwd, args, options = {}) {
+  return runCommandChecked("git", args, { cwd, ...options });
+}
+
+function listUniqueFiles(...groups) {
+  return [...new Set(groups.flat().filter(Boolean))].sort();
+}
+
+function normalizeMaxInlineFiles(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_INLINE_DIFF_MAX_FILES;
+  }
+  return Math.floor(parsed);
+}
+
+function normalizeMaxInlineDiffBytes(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_INLINE_DIFF_MAX_BYTES;
+  }
+  return Math.floor(parsed);
+}
+
+function measureGitOutputBytes(cwd, args, maxBytes) {
+  const result = git(cwd, args, { maxBuffer: maxBytes + 1 });
+  if (result.error && /** @type {NodeJS.ErrnoException} */ (result.error).code === "ENOBUFS") {
+    return maxBytes + 1;
+  }
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(formatCommandFailure(result));
+  }
+  return Buffer.byteLength(result.stdout, "utf8");
+}
+
+function measureCombinedGitOutputBytes(cwd, argSets, maxBytes) {
+  let totalBytes = 0;
+  for (const args of argSets) {
+    const remainingBytes = maxBytes - totalBytes;
+    if (remainingBytes < 0) {
+      return maxBytes + 1;
+    }
+    totalBytes += measureGitOutputBytes(cwd, args, remainingBytes);
+    if (totalBytes > maxBytes) {
+      return totalBytes;
+    }
+  }
+  return totalBytes;
+}
+
+function buildBranchComparison(cwd, baseRef) {
+  const mergeBase = gitChecked(cwd, ["merge-base", "HEAD", baseRef]).stdout.trim();
+  return {
+    mergeBase,
+    commitRange: `${mergeBase}..HEAD`,
+    reviewRange: `${baseRef}...HEAD`
+  };
+}
+
+export function ensureGitRepository(cwd) {
+  const result = git(cwd, ["rev-parse", "--show-toplevel"]);
+  const errorCode = result.error && "code" in result.error ? result.error.code : null;
+  if (errorCode === "ENOENT") {
+    throw new Error("git is not installed. Install Git and retry.");
+  }
+  if (result.status !== 0) {
+    throw new Error("This command must run inside a Git repository.");
+  }
+  return result.stdout.trim();
+}
+
+export function getRepoRoot(cwd) {
+  return gitChecked(cwd, ["rev-parse", "--show-toplevel"]).stdout.trim();
+}
+
+export function detectDefaultBranch(cwd) {
+  const symbolic = git(cwd, ["symbolic-ref", "refs/remotes/origin/HEAD"]);
+  if (symbolic.status === 0) {
+    const remoteHead = symbolic.stdout.trim();
+    if (remoteHead.startsWith("refs/remotes/origin/")) {
+      return remoteHead.replace("refs/remotes/origin/", "");
+    }
+  }
+
+  const candidates = ["main", "master", "trunk"];
+  for (const candidate of candidates) {
+    const local = git(cwd, ["show-ref", "--verify", "--quiet", `refs/heads/${candidate}`]);
+    if (local.status === 0) {
+      return candidate;
+    }
+    const remote = git(cwd, ["show-ref", "--verify", "--quiet", `refs/remotes/origin/${candidate}`]);
+    if (remote.status === 0) {
+      return `origin/${candidate}`;
+    }
+  }
+
+  throw new Error("Unable to detect the repository default branch. Pass --base <ref> or use --scope working-tree.");
+}
+
+export function getCurrentBranch(cwd) {
+  return gitChecked(cwd, ["branch", "--show-current"]).stdout.trim() || "HEAD";
+}
+
+export function getWorkingTreeState(cwd) {
+  const staged = gitChecked(cwd, ["diff", "--cached", "--name-only"]).stdout.trim().split("\n").filter(Boolean);
+  const unstaged = gitChecked(cwd, ["diff", "--name-only"]).stdout.trim().split("\n").filter(Boolean);
+  const untracked = gitChecked(cwd, ["ls-files", "--others", "--exclude-standard"]).stdout.trim().split("\n").filter(Boolean);
+
+  return {
+    staged,
+    unstaged,
+    untracked,
+    isDirty: staged.length > 0 || unstaged.length > 0 || untracked.length > 0
+  };
+}
+
+export function resolveReviewTarget(cwd, options = {}) {
+  ensureGitRepository(cwd);
+
+  const requestedScope = options.scope ?? "auto";
+  const baseRef = options.base ?? null;
+  const state = getWorkingTreeState(cwd);
+  const supportedScopes = new Set(["auto", "working-tree", "branch"]);
+
+  if (baseRef) {
+    return {
+      mode: "branch",
+      label: `branch diff against ${baseRef}`,
+      baseRef,
+      explicit: true
+    };
+  }
+
+  if (requestedScope === "working-tree") {
+    return {
+      mode: "working-tree",
+      label: "working tree diff",
+      explicit: true
+    };
+  }
+
+  if (!supportedScopes.has(requestedScope)) {
+    throw new Error(
+      `Unsupported review scope "${requestedScope}". Use one of: auto, working-tree, branch, or pass --base <ref>.`
+    );
+  }
+
+  if (requestedScope === "branch") {
+    const detectedBase = detectDefaultBranch(cwd);
+    return {
+      mode: "branch",
+      label: `branch diff against ${detectedBase}`,
+      baseRef: detectedBase,
+      explicit: true
+    };
+  }
+
+  if (state.isDirty) {
+    return {
+      mode: "working-tree",
+      label: "working tree diff",
+      explicit: false
+    };
+  }
+
+  const detectedBase = detectDefaultBranch(cwd);
+  return {
+    mode: "branch",
+    label: `branch diff against ${detectedBase}`,
+    baseRef: detectedBase,
+    explicit: false
+  };
+}
+
+function formatSection(title, body) {
+  return [`## ${title}`, "", body.trim() ? body.trim() : "(none)", ""].join("\n");
+}
+
+function formatUntrackedFile(cwd, relativePath) {
+  const absolutePath = path.join(cwd, relativePath);
+  let stat;
+  try {
+    stat = fs.statSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+  }
+  if (stat.isDirectory()) {
+    return `### ${relativePath}\n(skipped: directory)`;
+  }
+  if (stat.size > MAX_UNTRACKED_BYTES) {
+    return `### ${relativePath}\n(skipped: ${stat.size} bytes exceeds ${MAX_UNTRACKED_BYTES} byte limit)`;
+  }
+
+  let buffer;
+  try {
+    buffer = fs.readFileSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+  }
+  if (!isProbablyText(buffer)) {
+    return `### ${relativePath}\n(skipped: binary file)`;
+  }
+
+  return [`### ${relativePath}`, "```", buffer.toString("utf8").trimEnd(), "```"].join("\n");
+}
+
+function collectWorkingTreeContext(cwd, state, options = {}) {
+  const includeDiff = options.includeDiff !== false;
+  const status = gitChecked(cwd, ["status", "--short", "--untracked-files=all"]).stdout.trim();
+  const changedFiles = listUniqueFiles(state.staged, state.unstaged, state.untracked);
+
+  let parts;
+  if (includeDiff) {
+    const stagedDiff = gitChecked(cwd, ["diff", "--cached", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
+    const unstagedDiff = gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
+    const untrackedBody = state.untracked.map((file) => formatUntrackedFile(cwd, file)).join("\n\n");
+    parts = [
+      formatSection("Git Status", status),
+      formatSection("Staged Diff", stagedDiff),
+      formatSection("Unstaged Diff", unstagedDiff),
+      formatSection("Untracked Files", untrackedBody)
+    ];
+  } else {
+    const stagedStat = gitChecked(cwd, ["diff", "--shortstat", "--cached"]).stdout.trim();
+    const unstagedStat = gitChecked(cwd, ["diff", "--shortstat"]).stdout.trim();
+    const untrackedBody = state.untracked.map((file) => formatUntrackedFile(cwd, file)).join("\n\n");
+    parts = [
+      formatSection("Git Status", status),
+      formatSection("Staged Diff Stat", stagedStat),
+      formatSection("Unstaged Diff Stat", unstagedStat),
+      formatSection("Changed Files", changedFiles.join("\n")),
+      formatSection("Untracked Files", untrackedBody)
+    ];
+  }
+
+  return {
+    mode: "working-tree",
+    summary: `Reviewing ${state.staged.length} staged, ${state.unstaged.length} unstaged, and ${state.untracked.length} untracked file(s).`,
+    content: parts.join("\n"),
+    changedFiles
+  };
+}
+
+function collectBranchContext(cwd, baseRef, options = {}) {
+  const includeDiff = options.includeDiff !== false;
+  const comparison = options.comparison ?? buildBranchComparison(cwd, baseRef);
+  const currentBranch = getCurrentBranch(cwd);
+  const changedFiles = gitChecked(cwd, ["diff", "--name-only", comparison.commitRange]).stdout.trim().split("\n").filter(Boolean);
+  const logOutput = gitChecked(cwd, ["log", "--oneline", "--decorate", comparison.commitRange]).stdout.trim();
+  const diffStat = gitChecked(cwd, ["diff", "--stat", comparison.commitRange]).stdout.trim();
+
+  return {
+    mode: "branch",
+    summary: `Reviewing branch ${currentBranch} against ${baseRef} from merge-base ${comparison.mergeBase}.`,
+    content: includeDiff
+      ? [
+          formatSection("Commit Log", logOutput),
+          formatSection("Diff Stat", diffStat),
+          formatSection(
+            "Branch Diff",
+            gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff", comparison.commitRange]).stdout
+          )
+        ].join("\n")
+      : [
+          formatSection("Commit Log", logOutput),
+          formatSection("Diff Stat", diffStat),
+          formatSection("Changed Files", changedFiles.join("\n"))
+        ].join("\n"),
+    changedFiles,
+    comparison
+  };
+}
+
+function buildAdversarialCollectionGuidance(options = {}) {
+  if (options.includeDiff !== false) {
+    return "Use the repository context below as primary evidence.";
+  }
+
+  return "The repository context below is a lightweight summary. Inspect the target diff yourself with read-only git commands before finalizing findings.";
+}
+
+export function collectReviewContext(cwd, target, options = {}) {
+  const repoRoot = getRepoRoot(cwd);
+  const currentBranch = getCurrentBranch(repoRoot);
+  const maxInlineFiles = normalizeMaxInlineFiles(options.maxInlineFiles);
+  const maxInlineDiffBytes = normalizeMaxInlineDiffBytes(options.maxInlineDiffBytes);
+  let details;
+  let includeDiff;
+  let diffBytes;
+
+  if (target.mode === "working-tree") {
+    const state = getWorkingTreeState(repoRoot);
+    diffBytes = measureCombinedGitOutputBytes(
+      repoRoot,
+      [
+        ["diff", "--cached", "--binary", "--no-ext-diff", "--submodule=diff"],
+        ["diff", "--binary", "--no-ext-diff", "--submodule=diff"]
+      ],
+      maxInlineDiffBytes
+    );
+    includeDiff =
+      options.includeDiff ??
+      (listUniqueFiles(state.staged, state.unstaged, state.untracked).length <= maxInlineFiles &&
+        diffBytes <= maxInlineDiffBytes);
+    details = collectWorkingTreeContext(repoRoot, state, { includeDiff });
+  } else {
+    const comparison = buildBranchComparison(repoRoot, target.baseRef);
+    const fileCount = gitChecked(repoRoot, ["diff", "--name-only", comparison.commitRange]).stdout.trim().split("\n").filter(Boolean).length;
+    diffBytes = measureGitOutputBytes(
+      repoRoot,
+      ["diff", "--binary", "--no-ext-diff", "--submodule=diff", comparison.commitRange],
+      maxInlineDiffBytes
+    );
+    includeDiff = options.includeDiff ?? (fileCount <= maxInlineFiles && diffBytes <= maxInlineDiffBytes);
+    details = collectBranchContext(repoRoot, target.baseRef, { includeDiff, comparison });
+  }
+
+  return {
+    cwd: repoRoot,
+    repoRoot,
+    branch: currentBranch,
+    target,
+    fileCount: details.changedFiles.length,
+    diffBytes,
+    inputMode: includeDiff ? "inline-diff" : "self-collect",
+    collectionGuidance: buildAdversarialCollectionGuidance({ includeDiff }),
+    ...details
+  };
+}

--- a/scripts/crew-codex/lib/job-control.mjs
+++ b/scripts/crew-codex/lib/job-control.mjs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import fs from "node:fs";
+
+import { getSessionRuntimeStatus } from "./codex.mjs";
+import { getConfig, listJobs, readJobFile, resolveJobFile } from "./state.mjs";
+import { SESSION_ID_ENV } from "./tracked-jobs.mjs";
+import { resolveWorkspaceRoot } from "./workspace.mjs";
+
+export const DEFAULT_MAX_STATUS_JOBS = 8;
+export const DEFAULT_MAX_PROGRESS_LINES = 4;
+
+export function sortJobsNewestFirst(jobs) {
+  return [...jobs].sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
+}
+
+function getCurrentSessionId(options = {}) {
+  return options.env?.[SESSION_ID_ENV] ?? process.env[SESSION_ID_ENV] ?? null;
+}
+
+function filterJobsForCurrentSession(jobs, options = {}) {
+  const sessionId = getCurrentSessionId(options);
+  if (!sessionId) {
+    return jobs;
+  }
+  return jobs.filter((job) => job.sessionId === sessionId);
+}
+
+function getJobTypeLabel(job) {
+  if (typeof job.kindLabel === "string" && job.kindLabel) {
+    return job.kindLabel;
+  }
+  if (job.kind === "adversarial-review") {
+    return "adversarial-review";
+  }
+  if (job.jobClass === "review") {
+    return "review";
+  }
+  if (job.jobClass === "task") {
+    return "task";
+  }
+  if (job.kind === "review") {
+    return "review";
+  }
+  if (job.kind === "task") {
+    return "task";
+  }
+  return "job";
+}
+
+function stripLogPrefix(line) {
+  return line.replace(/^\[[^\]]+\]\s*/, "").trim();
+}
+
+function isProgressBlockTitle(line) {
+  return (
+    ["Final output", "Assistant message", "Reasoning summary", "Review output"].includes(line) ||
+    /^Subagent .+ message$/.test(line) ||
+    /^Subagent .+ reasoning summary$/.test(line)
+  );
+}
+
+export function readJobProgressPreview(logFile, maxLines = DEFAULT_MAX_PROGRESS_LINES) {
+  if (!logFile || !fs.existsSync(logFile)) {
+    return [];
+  }
+
+  const lines = fs
+    .readFileSync(logFile, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .filter((line) => line.startsWith("["))
+    .map(stripLogPrefix)
+    .filter((line) => line && !isProgressBlockTitle(line));
+
+  return lines.slice(-maxLines);
+}
+
+function formatElapsedDuration(startValue, endValue = null) {
+  const start = Date.parse(startValue ?? "");
+  if (!Number.isFinite(start)) {
+    return null;
+  }
+
+  const end = endValue ? Date.parse(endValue) : Date.now();
+  if (!Number.isFinite(end) || end < start) {
+    return null;
+  }
+
+  const totalSeconds = Math.max(0, Math.round((end - start) / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+function looksLikeVerificationCommand(line) {
+  return /\b(test|tests|lint|build|typecheck|type-check|check|verify|validate|pytest|jest|vitest|cargo test|npm test|pnpm test|yarn test|go test|mvn test|gradle test|tsc|eslint|ruff)\b/i.test(
+    line
+  );
+}
+
+function inferLegacyJobPhase(job, progressPreview = []) {
+  switch (job.status) {
+    case "queued":
+      return "queued";
+    case "cancelled":
+      return "cancelled";
+    case "failed":
+      return "failed";
+    case "completed":
+      return "done";
+    default:
+      break;
+  }
+
+  for (let index = progressPreview.length - 1; index >= 0; index -= 1) {
+    const line = progressPreview[index].toLowerCase();
+    if (line.startsWith("starting codex") || line.startsWith("thread ready") || line.startsWith("turn started")) {
+      return "starting";
+    }
+    if (line.startsWith("reviewer started") || line.includes("review mode")) {
+      return "reviewing";
+    }
+    if (line.startsWith("searching:") || line.startsWith("calling ") || line.startsWith("running tool:")) {
+      return "investigating";
+    }
+    if (line.startsWith("starting collaboration tool:")) {
+      return "investigating";
+    }
+    if (line.startsWith("running command:")) {
+      return looksLikeVerificationCommand(line)
+        ? "verifying"
+        : job.jobClass === "review"
+          ? "reviewing"
+          : "investigating";
+    }
+    if (line.startsWith("command completed:")) {
+      return looksLikeVerificationCommand(line) ? "verifying" : "running";
+    }
+    if (line.startsWith("applying ") || line.startsWith("file changes ")) {
+      return "editing";
+    }
+    if (line.startsWith("turn completed")) {
+      return "finalizing";
+    }
+    if (line.startsWith("codex error:") || line.startsWith("failed:")) {
+      return "failed";
+    }
+  }
+
+  return job.jobClass === "review" ? "reviewing" : "running";
+}
+
+export function enrichJob(job, options = {}) {
+  const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
+  const enriched = {
+    ...job,
+    kindLabel: getJobTypeLabel(job),
+    progressPreview:
+      job.status === "queued" || job.status === "running" || job.status === "failed"
+        ? readJobProgressPreview(job.logFile, maxProgressLines)
+        : [],
+    elapsed: formatElapsedDuration(job.startedAt ?? job.createdAt, job.completedAt ?? null),
+    duration:
+      job.status === "completed" || job.status === "failed" || job.status === "cancelled"
+        ? formatElapsedDuration(job.startedAt ?? job.createdAt, job.completedAt ?? job.updatedAt)
+        : null
+  };
+
+  return {
+    ...enriched,
+    phase: enriched.phase ?? inferLegacyJobPhase(enriched, enriched.progressPreview)
+  };
+}
+
+export function readStoredJob(workspaceRoot, jobId) {
+  const jobFile = resolveJobFile(workspaceRoot, jobId);
+  if (!fs.existsSync(jobFile)) {
+    return null;
+  }
+  return readJobFile(jobFile);
+}
+
+function matchJobReference(jobs, reference, predicate = () => true) {
+  const filtered = jobs.filter(predicate);
+  if (!reference) {
+    return filtered[0] ?? null;
+  }
+
+  const exact = filtered.find((job) => job.id === reference);
+  if (exact) {
+    return exact;
+  }
+
+  const prefixMatches = filtered.filter((job) => job.id.startsWith(reference));
+  if (prefixMatches.length === 1) {
+    return prefixMatches[0];
+  }
+  if (prefixMatches.length > 1) {
+    throw new Error(`Job reference "${reference}" is ambiguous. Use a longer job id.`);
+  }
+
+  throw new Error(`No job found for "${reference}". Run crew-codex status to list known jobs.`);
+}
+
+export function buildStatusSnapshot(cwd, options = {}) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const config = getConfig(workspaceRoot);
+  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), options));
+  const maxJobs = options.maxJobs ?? DEFAULT_MAX_STATUS_JOBS;
+  const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
+
+  const running = jobs
+    .filter((job) => job.status === "queued" || job.status === "running")
+    .map((job) => enrichJob(job, { maxProgressLines }));
+
+  const latestFinishedRaw = jobs.find((job) => job.status !== "queued" && job.status !== "running") ?? null;
+  const latestFinished = latestFinishedRaw ? enrichJob(latestFinishedRaw, { maxProgressLines }) : null;
+
+  const recent = (options.all ? jobs : jobs.slice(0, maxJobs))
+    .filter((job) => job.status !== "queued" && job.status !== "running" && job.id !== latestFinished?.id)
+    .map((job) => enrichJob(job, { maxProgressLines }));
+
+  return {
+    workspaceRoot,
+    config,
+    sessionRuntime: getSessionRuntimeStatus(options.env, workspaceRoot),
+    running,
+    latestFinished,
+    recent,
+    needsReview: Boolean(config.stopReviewGate)
+  };
+}
+
+export function buildSingleJobSnapshot(cwd, reference, options = {}) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const selected = matchJobReference(jobs, reference);
+  if (!selected) {
+    throw new Error(`No job found for "${reference}". Run crew-codex status to inspect known jobs.`);
+  }
+
+  return {
+    workspaceRoot,
+    job: enrichJob(selected, { maxProgressLines: options.maxProgressLines })
+  };
+}
+
+export function resolveResultJob(cwd, reference) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const jobs = sortJobsNewestFirst(reference ? listJobs(workspaceRoot) : filterJobsForCurrentSession(listJobs(workspaceRoot)));
+  const selected = matchJobReference(
+    jobs,
+    reference,
+    (job) => job.status === "completed" || job.status === "failed" || job.status === "cancelled"
+  );
+
+  if (selected) {
+    return { workspaceRoot, job: selected };
+  }
+
+  const active = matchJobReference(jobs, reference, (job) => job.status === "queued" || job.status === "running");
+  if (active) {
+    throw new Error(`Job ${active.id} is still ${active.status}. Check crew-codex status and try again once it finishes.`);
+  }
+
+  if (reference) {
+    throw new Error(`No finished job found for "${reference}". Run crew-codex status to inspect active jobs.`);
+  }
+
+  throw new Error("No finished Codex jobs found for this repository yet.");
+}
+
+export function resolveCancelableJob(cwd, reference, options = {}) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const activeJobs = jobs.filter((job) => job.status === "queued" || job.status === "running");
+
+  if (reference) {
+    const selected = matchJobReference(activeJobs, reference);
+    if (!selected) {
+      throw new Error(`No active job found for "${reference}".`);
+    }
+    return { workspaceRoot, job: selected };
+  }
+
+  const sessionScopedActiveJobs = filterJobsForCurrentSession(activeJobs, options);
+
+  if (sessionScopedActiveJobs.length === 1) {
+    return { workspaceRoot, job: sessionScopedActiveJobs[0] };
+  }
+  if (sessionScopedActiveJobs.length > 1) {
+    throw new Error("Multiple Codex jobs are active. Pass a job id to crew-codex cancel.");
+  }
+
+  if (getCurrentSessionId(options)) {
+    throw new Error("No active Codex jobs to cancel for this session.");
+  }
+
+  throw new Error("No active Codex jobs to cancel.");
+}

--- a/scripts/crew-codex/lib/process.mjs
+++ b/scripts/crew-codex/lib/process.mjs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+export function runCommand(command, args = [], options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: "utf8",
+    input: options.input,
+    maxBuffer: options.maxBuffer,
+    stdio: options.stdio ?? "pipe",
+    shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+    windowsHide: true
+  });
+
+  return {
+    command,
+    args,
+    status: result.status ?? 0,
+    signal: result.signal ?? null,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    error: result.error ?? null
+  };
+}
+
+export function runCommandChecked(command, args = [], options = {}) {
+  const result = runCommand(command, args, options);
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(formatCommandFailure(result));
+  }
+  return result;
+}
+
+export function binaryAvailable(command, versionArgs = ["--version"], options = {}) {
+  const result = runCommand(command, versionArgs, options);
+  if (result.error && /** @type {NodeJS.ErrnoException} */ (result.error).code === "ENOENT") {
+    return { available: false, detail: "not found" };
+  }
+  if (result.error) {
+    return { available: false, detail: result.error.message };
+  }
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
+    return { available: false, detail };
+  }
+  return { available: true, detail: result.stdout.trim() || result.stderr.trim() || "ok" };
+}
+
+function looksLikeMissingProcessMessage(text) {
+  return /not found|no running instance|cannot find|does not exist|no such process/i.test(text);
+}
+
+export function terminateProcessTree(pid, options = {}) {
+  if (!Number.isFinite(pid)) {
+    return { attempted: false, delivered: false, method: null };
+  }
+
+  const platform = options.platform ?? process.platform;
+  const runCommandImpl = options.runCommandImpl ?? runCommand;
+  const killImpl = options.killImpl ?? process.kill.bind(process);
+
+  if (platform === "win32") {
+    const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
+      cwd: options.cwd,
+      env: options.env
+    });
+
+    if (!result.error && result.status === 0) {
+      return { attempted: true, delivered: true, method: "taskkill", result };
+    }
+
+    const combinedOutput = `${result.stderr}\n${result.stdout}`.trim();
+    if (!result.error && looksLikeMissingProcessMessage(combinedOutput)) {
+      return { attempted: true, delivered: false, method: "taskkill", result };
+    }
+
+    if (result.error?.code === "ENOENT") {
+      try {
+        killImpl(pid);
+        return { attempted: true, delivered: true, method: "kill" };
+      } catch (error) {
+        if (error?.code === "ESRCH") {
+          return { attempted: true, delivered: false, method: "kill" };
+        }
+        throw error;
+      }
+    }
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    throw new Error(formatCommandFailure(result));
+  }
+
+  try {
+    killImpl(-pid, "SIGTERM");
+    return { attempted: true, delivered: true, method: "process-group" };
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      try {
+        killImpl(pid, "SIGTERM");
+        return { attempted: true, delivered: true, method: "process" };
+      } catch (innerError) {
+        if (innerError?.code === "ESRCH") {
+          return { attempted: true, delivered: false, method: "process" };
+        }
+        throw innerError;
+      }
+    }
+
+    return { attempted: true, delivered: false, method: "process-group" };
+  }
+}
+
+export function formatCommandFailure(result) {
+  const parts = [`${result.command} ${result.args.join(" ")}`.trim()];
+  if (result.signal) {
+    parts.push(`signal=${result.signal}`);
+  } else {
+    parts.push(`exit=${result.status}`);
+  }
+  const stderr = (result.stderr || "").trim();
+  const stdout = (result.stdout || "").trim();
+  if (stderr) {
+    parts.push(stderr);
+  } else if (stdout) {
+    parts.push(stdout);
+  }
+  return parts.join(": ");
+}

--- a/scripts/crew-codex/lib/process.mjs
+++ b/scripts/crew-codex/lib/process.mjs
@@ -11,7 +11,7 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+    shell: process.platform === "win32",
     windowsHide: true
   });
 

--- a/scripts/crew-codex/lib/prompts.mjs
+++ b/scripts/crew-codex/lib/prompts.mjs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import fs from "node:fs";
+import path from "node:path";
+
+export function loadPromptTemplate(rootDir, name) {
+  const promptPath = path.join(rootDir, "prompts", `${name}.md`);
+  return fs.readFileSync(promptPath, "utf8");
+}
+
+export function interpolateTemplate(template, variables) {
+  return template.replace(/\{\{([A-Z_]+)\}\}/g, (_, key) => {
+    return Object.prototype.hasOwnProperty.call(variables, key) ? variables[key] : "";
+  });
+}

--- a/scripts/crew-codex/lib/render.mjs
+++ b/scripts/crew-codex/lib/render.mjs
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+function severityRank(severity) {
+  switch (severity) {
+    case "critical":
+      return 0;
+    case "high":
+      return 1;
+    case "medium":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+function formatLineRange(finding) {
+  if (!finding.line_start) {
+    return "";
+  }
+  if (!finding.line_end || finding.line_end === finding.line_start) {
+    return `:${finding.line_start}`;
+  }
+  return `:${finding.line_start}-${finding.line_end}`;
+}
+
+function validateReviewResultShape(data) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return "Expected a top-level JSON object.";
+  }
+  if (typeof data.verdict !== "string" || !data.verdict.trim()) {
+    return "Missing string `verdict`.";
+  }
+  if (typeof data.summary !== "string" || !data.summary.trim()) {
+    return "Missing string `summary`.";
+  }
+  if (!Array.isArray(data.findings)) {
+    return "Missing array `findings`.";
+  }
+  if (!Array.isArray(data.next_steps)) {
+    return "Missing array `next_steps`.";
+  }
+  return null;
+}
+
+function normalizeReviewFinding(finding, index) {
+  const source = finding && typeof finding === "object" && !Array.isArray(finding) ? finding : {};
+  const lineStart = Number.isInteger(source.line_start) && source.line_start > 0 ? source.line_start : null;
+  const lineEnd =
+    Number.isInteger(source.line_end) && source.line_end > 0 && (!lineStart || source.line_end >= lineStart)
+      ? source.line_end
+      : lineStart;
+
+  return {
+    severity: typeof source.severity === "string" && source.severity.trim() ? source.severity.trim() : "low",
+    title: typeof source.title === "string" && source.title.trim() ? source.title.trim() : `Finding ${index + 1}`,
+    body: typeof source.body === "string" && source.body.trim() ? source.body.trim() : "No details provided.",
+    file: typeof source.file === "string" && source.file.trim() ? source.file.trim() : "unknown",
+    line_start: lineStart,
+    line_end: lineEnd,
+    recommendation: typeof source.recommendation === "string" ? source.recommendation.trim() : ""
+  };
+}
+
+function normalizeReviewResultData(data) {
+  return {
+    verdict: data.verdict.trim(),
+    summary: data.summary.trim(),
+    findings: data.findings.map((finding, index) => normalizeReviewFinding(finding, index)),
+    next_steps: data.next_steps
+      .filter((step) => typeof step === "string" && step.trim())
+      .map((step) => step.trim())
+  };
+}
+
+function isStructuredReviewStoredResult(storedJob) {
+  const result = storedJob?.result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return false;
+  }
+  return (
+    Object.prototype.hasOwnProperty.call(result, "result") ||
+    Object.prototype.hasOwnProperty.call(result, "parseError")
+  );
+}
+
+function formatJobLine(job) {
+  const parts = [job.id, `${job.status || "unknown"}`];
+  if (job.kindLabel) {
+    parts.push(job.kindLabel);
+  }
+  if (job.title) {
+    parts.push(job.title);
+  }
+  return parts.join(" | ");
+}
+
+function escapeMarkdownCell(value) {
+  return String(value ?? "")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ")
+    .trim();
+}
+
+function formatCodexResumeCommand(job) {
+  if (!job?.threadId) {
+    return null;
+  }
+  return `codex resume ${job.threadId}`;
+}
+
+function appendActiveJobsTable(lines, jobs) {
+  lines.push("Active jobs:");
+  lines.push("| Job | Kind | Status | Phase | Elapsed | Codex Session ID | Summary | Actions |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
+  for (const job of jobs) {
+    const actions = [`crew-codex status ${job.id}`];
+    if (job.status === "queued" || job.status === "running") {
+      actions.push(`crew-codex cancel ${job.id}`);
+    }
+    lines.push(
+      `| ${escapeMarkdownCell(job.id)} | ${escapeMarkdownCell(job.kindLabel)} | ${escapeMarkdownCell(job.status)} | ${escapeMarkdownCell(job.phase ?? "")} | ${escapeMarkdownCell(job.elapsed ?? "")} | ${escapeMarkdownCell(job.threadId ?? "")} | ${escapeMarkdownCell(job.summary ?? "")} | ${actions.map((action) => `\`${action}\``).join("<br>")} |`
+    );
+  }
+}
+
+function pushJobDetails(lines, job, options = {}) {
+  lines.push(`- ${formatJobLine(job)}`);
+  if (job.summary) {
+    lines.push(`  Summary: ${job.summary}`);
+  }
+  if (job.phase) {
+    lines.push(`  Phase: ${job.phase}`);
+  }
+  if (options.showElapsed && job.elapsed) {
+    lines.push(`  Elapsed: ${job.elapsed}`);
+  }
+  if (options.showDuration && job.duration) {
+    lines.push(`  Duration: ${job.duration}`);
+  }
+  if (job.threadId) {
+    lines.push(`  Codex session ID: ${job.threadId}`);
+  }
+  const resumeCommand = formatCodexResumeCommand(job);
+  if (resumeCommand) {
+    lines.push(`  Resume in Codex: ${resumeCommand}`);
+  }
+  if (job.logFile && options.showLog) {
+    lines.push(`  Log: ${job.logFile}`);
+  }
+  if ((job.status === "queued" || job.status === "running") && options.showCancelHint) {
+    lines.push(`  Cancel: crew-codex cancel ${job.id}`);
+  }
+  if (job.status !== "queued" && job.status !== "running" && options.showResultHint) {
+    lines.push(`  Result: crew-codex result ${job.id}`);
+  }
+  if (job.status !== "queued" && job.status !== "running" && job.jobClass === "task" && job.write && options.showReviewHint) {
+    lines.push("  Review changes before shipping.");
+  }
+  if (job.progressPreview?.length) {
+    lines.push("  Progress:");
+    for (const line of job.progressPreview) {
+      lines.push(`    ${line}`);
+    }
+  }
+}
+
+function appendReasoningSection(lines, reasoningSummary) {
+  if (!Array.isArray(reasoningSummary) || reasoningSummary.length === 0) {
+    return;
+  }
+
+  lines.push("", "Reasoning:");
+  for (const section of reasoningSummary) {
+    lines.push(`- ${section}`);
+  }
+}
+
+export function renderSetupReport(report) {
+  const lines = [
+    "# Codex Setup",
+    "",
+    `Status: ${report.ready ? "ready" : "needs attention"}`,
+    "",
+    "Checks:",
+    `- node: ${report.node.detail}`,
+    `- npm: ${report.npm.detail}`,
+    `- codex: ${report.codex.detail}`,
+    `- auth: ${report.auth.detail}`,
+    `- session runtime: ${report.sessionRuntime.label}`,
+    `- review gate: ${report.reviewGateEnabled ? "enabled" : "disabled"}`,
+    ""
+  ];
+
+  if (report.actionsTaken.length > 0) {
+    lines.push("Actions taken:");
+    for (const action of report.actionsTaken) {
+      lines.push(`- ${action}`);
+    }
+    lines.push("");
+  }
+
+  if (report.nextSteps.length > 0) {
+    lines.push("Next steps:");
+    for (const step of report.nextSteps) {
+      lines.push(`- ${step}`);
+    }
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderReviewResult(parsedResult, meta) {
+  if (!parsedResult.parsed) {
+    const lines = [
+      `# Codex ${meta.reviewLabel}`,
+      "",
+      "Codex did not return valid structured JSON.",
+      "",
+      `- Parse error: ${parsedResult.parseError}`
+    ];
+
+    if (parsedResult.rawOutput) {
+      lines.push("", "Raw final message:", "", "```text", parsedResult.rawOutput, "```");
+    }
+
+    appendReasoningSection(lines, meta.reasoningSummary ?? parsedResult.reasoningSummary);
+
+    return `${lines.join("\n").trimEnd()}\n`;
+  }
+
+  const validationError = validateReviewResultShape(parsedResult.parsed);
+  if (validationError) {
+    const lines = [
+      `# Codex ${meta.reviewLabel}`,
+      "",
+      `Target: ${meta.targetLabel}`,
+      "Codex returned JSON with an unexpected review shape.",
+      "",
+      `- Validation error: ${validationError}`
+    ];
+
+    if (parsedResult.rawOutput) {
+      lines.push("", "Raw final message:", "", "```text", parsedResult.rawOutput, "```");
+    }
+
+    appendReasoningSection(lines, meta.reasoningSummary ?? parsedResult.reasoningSummary);
+
+    return `${lines.join("\n").trimEnd()}\n`;
+  }
+
+  const data = normalizeReviewResultData(parsedResult.parsed);
+  const findings = [...data.findings].sort((left, right) => severityRank(left.severity) - severityRank(right.severity));
+  const lines = [
+    `# Codex ${meta.reviewLabel}`,
+    "",
+    `Target: ${meta.targetLabel}`,
+    `Verdict: ${data.verdict}`,
+    "",
+    data.summary,
+    ""
+  ];
+
+  if (findings.length === 0) {
+    lines.push("No material findings.");
+  } else {
+    lines.push("Findings:");
+    for (const finding of findings) {
+      const lineSuffix = formatLineRange(finding);
+      lines.push(`- [${finding.severity}] ${finding.title} (${finding.file}${lineSuffix})`);
+      lines.push(`  ${finding.body}`);
+      if (finding.recommendation) {
+        lines.push(`  Recommendation: ${finding.recommendation}`);
+      }
+    }
+  }
+
+  if (data.next_steps.length > 0) {
+    lines.push("", "Next steps:");
+    for (const step of data.next_steps) {
+      lines.push(`- ${step}`);
+    }
+  }
+
+  appendReasoningSection(lines, meta.reasoningSummary);
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderNativeReviewResult(result, meta) {
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
+  const lines = [
+    `# Codex ${meta.reviewLabel}`,
+    "",
+    `Target: ${meta.targetLabel}`,
+    ""
+  ];
+
+  if (stdout) {
+    lines.push(stdout);
+  } else if (result.status === 0) {
+    lines.push("Codex review completed without any stdout output.");
+  } else {
+    lines.push("Codex review failed.");
+  }
+
+  if (stderr) {
+    lines.push("", "stderr:", "", "```text", stderr, "```");
+  }
+
+  appendReasoningSection(lines, meta.reasoningSummary);
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderTaskResult(parsedResult, meta) {
+  const rawOutput = typeof parsedResult?.rawOutput === "string" ? parsedResult.rawOutput : "";
+  if (rawOutput) {
+    return rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`;
+  }
+
+  const message = String(parsedResult?.failureMessage ?? "").trim() || "Codex did not return a final message.";
+  return `${message}\n`;
+}
+
+export function renderStatusReport(report) {
+  const lines = [
+    "# Codex Status",
+    "",
+    `Session runtime: ${report.sessionRuntime.label}`,
+    `Review gate: ${report.config.stopReviewGate ? "enabled" : "disabled"}`,
+    ""
+  ];
+
+  if (report.running.length > 0) {
+    appendActiveJobsTable(lines, report.running);
+    lines.push("");
+    lines.push("Live details:");
+    for (const job of report.running) {
+      pushJobDetails(lines, job, {
+        showElapsed: true,
+        showLog: true
+      });
+    }
+    lines.push("");
+  }
+
+  if (report.latestFinished) {
+    lines.push("Latest finished:");
+    pushJobDetails(lines, report.latestFinished, {
+      showDuration: true,
+      showLog: report.latestFinished.status === "failed"
+    });
+    lines.push("");
+  }
+
+  if (report.recent.length > 0) {
+    lines.push("Recent jobs:");
+    for (const job of report.recent) {
+      pushJobDetails(lines, job, {
+        showDuration: true,
+        showLog: job.status === "failed"
+      });
+    }
+    lines.push("");
+  } else if (report.running.length === 0 && !report.latestFinished) {
+    lines.push("No jobs recorded yet.", "");
+  }
+
+  if (report.needsReview) {
+    lines.push("The stop-time review gate is enabled.");
+    lines.push("Ending the session will trigger a fresh Codex adversarial review and block if it finds issues.");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderJobStatusReport(job) {
+  const lines = ["# Codex Job Status", ""];
+  pushJobDetails(lines, job, {
+    showElapsed: job.status === "queued" || job.status === "running",
+    showDuration: job.status !== "queued" && job.status !== "running",
+    showLog: true,
+    showCancelHint: true,
+    showResultHint: true,
+    showReviewHint: true
+  });
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderStoredJobResult(job, storedJob) {
+  const threadId = storedJob?.threadId ?? job.threadId ?? null;
+  const resumeCommand = threadId ? `codex resume ${threadId}` : null;
+  if (isStructuredReviewStoredResult(storedJob) && storedJob?.rendered) {
+    const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
+    if (!threadId) {
+      return output;
+    }
+    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+  }
+
+  const rawOutput =
+    (typeof storedJob?.result?.rawOutput === "string" && storedJob.result.rawOutput) ||
+    (typeof storedJob?.result?.codex?.stdout === "string" && storedJob.result.codex.stdout) ||
+    "";
+  if (rawOutput) {
+    const output = rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`;
+    if (!threadId) {
+      return output;
+    }
+    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+  }
+
+  if (storedJob?.rendered) {
+    const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
+    if (!threadId) {
+      return output;
+    }
+    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+  }
+
+  const lines = [
+    `# ${job.title ?? "Codex Result"}`,
+    "",
+    `Job: ${job.id}`,
+    `Status: ${job.status}`
+  ];
+
+  if (threadId) {
+    lines.push(`Codex session ID: ${threadId}`);
+    lines.push(`Resume in Codex: ${resumeCommand}`);
+  }
+
+  if (job.summary) {
+    lines.push(`Summary: ${job.summary}`);
+  }
+
+  if (job.errorMessage) {
+    lines.push("", job.errorMessage);
+  } else if (storedJob?.errorMessage) {
+    lines.push("", storedJob.errorMessage);
+  } else {
+    lines.push("", "No captured result payload was stored for this job.");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderCancelReport(job) {
+  const lines = [
+    "# Codex Cancel",
+    "",
+    `Cancelled ${job.id}.`,
+    ""
+  ];
+
+  if (job.title) {
+    lines.push(`- Title: ${job.title}`);
+  }
+  if (job.summary) {
+    lines.push(`- Summary: ${job.summary}`);
+  }
+  lines.push("- Check `crew-codex status` for the updated queue.");
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/scripts/crew-codex/lib/state.mjs
+++ b/scripts/crew-codex/lib/state.mjs
@@ -12,6 +12,9 @@ const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
 const FALLBACK_STATE_ROOT_DIR = path.join(os.tmpdir(), "crew-codex-companion");
 const STATE_FILE_NAME = "state.json";
 const JOBS_DIR_NAME = "jobs";
+const LOCK_DIR_NAME = ".lock";
+const LOCK_WAIT_TIMEOUT_MS = 10000;
+const LOCK_POLL_INTERVAL_MS = 50;
 const MAX_JOBS = 50;
 
 function nowIso() {
@@ -57,6 +60,102 @@ export function ensureStateDir(cwd) {
   fs.mkdirSync(resolveJobsDir(cwd), { recursive: true });
 }
 
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveLockDir(cwd) {
+  return path.join(resolveStateDir(cwd), LOCK_DIR_NAME);
+}
+
+function writeLockOwner(lockDir) {
+  fs.writeFileSync(
+    path.join(lockDir, "owner.json"),
+    `${JSON.stringify({ pid: process.pid, createdAt: nowIso() }, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+function acquireStateLock(cwd, options = {}) {
+  const timeoutMs = options.timeoutMs ?? LOCK_WAIT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? LOCK_POLL_INTERVAL_MS;
+  const stateDir = resolveStateDir(cwd);
+  const lockDir = resolveLockDir(cwd);
+  const startedAt = Date.now();
+  fs.mkdirSync(stateDir, { recursive: true });
+
+  while (true) {
+    try {
+      fs.mkdirSync(lockDir);
+      writeLockOwner(lockDir);
+      return lockDir;
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`Timed out waiting for Codex companion state lock: ${lockDir}`);
+      }
+      sleepSync(pollIntervalMs);
+    }
+  }
+}
+
+async function acquireStateLockAsync(cwd, options = {}) {
+  const timeoutMs = options.timeoutMs ?? LOCK_WAIT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? LOCK_POLL_INTERVAL_MS;
+  const stateDir = resolveStateDir(cwd);
+  const lockDir = resolveLockDir(cwd);
+  const startedAt = Date.now();
+  fs.mkdirSync(stateDir, { recursive: true });
+
+  while (true) {
+    try {
+      fs.mkdirSync(lockDir);
+      writeLockOwner(lockDir);
+      return lockDir;
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`Timed out waiting for Codex companion state lock: ${lockDir}`);
+      }
+      await sleep(pollIntervalMs);
+    }
+  }
+}
+
+function releaseStateLock(lockDir) {
+  try {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  } catch {
+    // Lock release is best-effort; callers should not fail after their write completed.
+  }
+}
+
+export function withStateLock(cwd, callback, options = {}) {
+  const lockDir = acquireStateLock(cwd, options);
+  try {
+    return callback();
+  } finally {
+    releaseStateLock(lockDir);
+  }
+}
+
+export async function withStateLockAsync(cwd, callback, options = {}) {
+  const lockDir = await acquireStateLockAsync(cwd, options);
+  try {
+    return await callback();
+  } finally {
+    releaseStateLock(lockDir);
+  }
+}
+
 export function loadState(cwd) {
   const stateFile = resolveStateFile(cwd);
   if (!fs.existsSync(stateFile)) {
@@ -91,7 +190,17 @@ function removeFileIfExists(filePath) {
   }
 }
 
-export function saveState(cwd, state) {
+export function writeJsonFileAtomic(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`
+  );
+  fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  fs.renameSync(tempPath, filePath);
+}
+
+function saveStateUnlocked(cwd, state) {
   const previousJobs = loadState(cwd).jobs;
   ensureStateDir(cwd);
   const nextJobs = pruneJobs(state.jobs ?? []);
@@ -113,14 +222,20 @@ export function saveState(cwd, state) {
     removeFileIfExists(job.logFile);
   }
 
-  fs.writeFileSync(resolveStateFile(cwd), `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  writeJsonFileAtomic(resolveStateFile(cwd), nextState);
   return nextState;
 }
 
+export function saveState(cwd, state) {
+  return withStateLock(cwd, () => saveStateUnlocked(cwd, state));
+}
+
 export function updateState(cwd, mutate) {
-  const state = loadState(cwd);
-  mutate(state);
-  return saveState(cwd, state);
+  return withStateLock(cwd, () => {
+    const state = loadState(cwd);
+    mutate(state);
+    return saveStateUnlocked(cwd, state);
+  });
 }
 
 export function generateJobId(prefix = "job") {
@@ -168,7 +283,7 @@ export function getConfig(cwd) {
 export function writeJobFile(cwd, jobId, payload) {
   ensureStateDir(cwd);
   const jobFile = resolveJobFile(cwd, jobId);
-  fs.writeFileSync(jobFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  writeJsonFileAtomic(jobFile, payload);
   return jobFile;
 }
 

--- a/scripts/crew-codex/lib/state.mjs
+++ b/scripts/crew-codex/lib/state.mjs
@@ -15,6 +15,7 @@ const JOBS_DIR_NAME = "jobs";
 const LOCK_DIR_NAME = ".lock";
 const LOCK_WAIT_TIMEOUT_MS = 10000;
 const LOCK_POLL_INTERVAL_MS = 50;
+const LOCK_STALE_AFTER_MS = 60000;
 const MAX_JOBS = 50;
 
 function nowIso() {
@@ -80,6 +81,62 @@ function writeLockOwner(lockDir) {
   );
 }
 
+function readLockOwner(lockDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(lockDir, "owner.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function getLockAgeMs(lockDir, owner) {
+  const createdAt = Date.parse(owner?.createdAt ?? "");
+  if (Number.isFinite(createdAt)) {
+    return Date.now() - createdAt;
+  }
+  try {
+    return Date.now() - fs.statSync(lockDir).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function removeStaleLock(lockDir, owner) {
+  try {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  } catch (error) {
+    throw new Error(
+      `Failed to remove stale Codex companion state lock held by pid ${owner?.pid ?? "unknown"}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
+function maybeRemoveStaleLock(lockDir, options = {}) {
+  const staleAfterMs = options.staleAfterMs ?? LOCK_STALE_AFTER_MS;
+  const owner = readLockOwner(lockDir);
+  const ageMs = getLockAgeMs(lockDir, owner);
+  const ownerAlive = isProcessAlive(owner?.pid);
+  if (!ownerAlive || ageMs >= staleAfterMs) {
+    removeStaleLock(lockDir, owner);
+    return true;
+  }
+  return false;
+}
+
 function acquireStateLock(cwd, options = {}) {
   const timeoutMs = options.timeoutMs ?? LOCK_WAIT_TIMEOUT_MS;
   const pollIntervalMs = options.pollIntervalMs ?? LOCK_POLL_INTERVAL_MS;
@@ -99,6 +156,9 @@ function acquireStateLock(cwd, options = {}) {
       }
       if (Date.now() - startedAt >= timeoutMs) {
         throw new Error(`Timed out waiting for Codex companion state lock: ${lockDir}`);
+      }
+      if (maybeRemoveStaleLock(lockDir, options)) {
+        continue;
       }
       sleepSync(pollIntervalMs);
     }
@@ -124,6 +184,9 @@ async function acquireStateLockAsync(cwd, options = {}) {
       }
       if (Date.now() - startedAt >= timeoutMs) {
         throw new Error(`Timed out waiting for Codex companion state lock: ${lockDir}`);
+      }
+      if (maybeRemoveStaleLock(lockDir, options)) {
+        continue;
       }
       await sleep(pollIntervalMs);
     }

--- a/scripts/crew-codex/lib/state.mjs
+++ b/scripts/crew-codex/lib/state.mjs
@@ -334,6 +334,51 @@ export function upsertJob(cwd, jobPatch) {
   });
 }
 
+export function updateJobStateAndFile(cwd, jobId, mutate) {
+  return withStateLock(cwd, () => {
+    const state = loadState(cwd);
+    const timestamp = nowIso();
+    const existingIndex = state.jobs.findIndex((job) => job.id === jobId);
+    const existingJob = existingIndex === -1 ? null : state.jobs[existingIndex];
+    const result = mutate(existingJob, { timestamp });
+    if (!result) {
+      return null;
+    }
+
+    const stateJob = result.stateJob ?? result.job ?? null;
+    if (!stateJob) {
+      return null;
+    }
+
+    const nextStateJob = {
+      ...(existingJob ?? {
+        createdAt: timestamp
+      }),
+      ...stateJob,
+      id: jobId,
+      updatedAt: stateJob.updatedAt ?? timestamp
+    };
+
+    if (existingIndex === -1) {
+      state.jobs.unshift(nextStateJob);
+    } else {
+      state.jobs[existingIndex] = nextStateJob;
+    }
+
+    const nextState = saveStateUnlocked(cwd, state);
+    const fileJob = result.fileJob ?? nextStateJob;
+    if (fileJob) {
+      writeJsonFileAtomic(resolveJobFile(cwd, jobId), fileJob);
+    }
+
+    return {
+      state: nextState,
+      job: nextStateJob,
+      fileJob
+    };
+  });
+}
+
 export function listJobs(cwd) {
   return loadState(cwd).jobs;
 }

--- a/scripts/crew-codex/lib/state.mjs
+++ b/scripts/crew-codex/lib/state.mjs
@@ -129,8 +129,16 @@ function maybeRemoveStaleLock(lockDir, options = {}) {
   const staleAfterMs = options.staleAfterMs ?? LOCK_STALE_AFTER_MS;
   const owner = readLockOwner(lockDir);
   const ageMs = getLockAgeMs(lockDir, owner);
-  const ownerAlive = isProcessAlive(owner?.pid);
-  if (!ownerAlive || ageMs >= staleAfterMs) {
+
+  if (!owner) {
+    if (ageMs >= staleAfterMs) {
+      removeStaleLock(lockDir, owner);
+      return true;
+    }
+    return false;
+  }
+
+  if (!isProcessAlive(owner.pid) || ageMs >= staleAfterMs) {
     removeStaleLock(lockDir, owner);
     return true;
   }

--- a/scripts/crew-codex/lib/state.mjs
+++ b/scripts/crew-codex/lib/state.mjs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveWorkspaceRoot } from "./workspace.mjs";
+
+const STATE_VERSION = 1;
+const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
+const FALLBACK_STATE_ROOT_DIR = path.join(os.tmpdir(), "crew-codex-companion");
+const STATE_FILE_NAME = "state.json";
+const JOBS_DIR_NAME = "jobs";
+const MAX_JOBS = 50;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function defaultState() {
+  return {
+    version: STATE_VERSION,
+    config: {
+      stopReviewGate: false
+    },
+    jobs: []
+  };
+}
+
+export function resolveStateDir(cwd) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  let canonicalWorkspaceRoot = workspaceRoot;
+  try {
+    canonicalWorkspaceRoot = fs.realpathSync.native(workspaceRoot);
+  } catch {
+    canonicalWorkspaceRoot = workspaceRoot;
+  }
+
+  const slugSource = path.basename(workspaceRoot) || "workspace";
+  const slug = slugSource.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "workspace";
+  const hash = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex").slice(0, 16);
+  const pluginDataDir = process.env[PLUGIN_DATA_ENV];
+  const stateRoot = pluginDataDir ? path.join(pluginDataDir, "state") : FALLBACK_STATE_ROOT_DIR;
+  return path.join(stateRoot, `${slug}-${hash}`);
+}
+
+export function resolveStateFile(cwd) {
+  return path.join(resolveStateDir(cwd), STATE_FILE_NAME);
+}
+
+export function resolveJobsDir(cwd) {
+  return path.join(resolveStateDir(cwd), JOBS_DIR_NAME);
+}
+
+export function ensureStateDir(cwd) {
+  fs.mkdirSync(resolveJobsDir(cwd), { recursive: true });
+}
+
+export function loadState(cwd) {
+  const stateFile = resolveStateFile(cwd);
+  if (!fs.existsSync(stateFile)) {
+    return defaultState();
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+    return {
+      ...defaultState(),
+      ...parsed,
+      config: {
+        ...defaultState().config,
+        ...(parsed.config ?? {})
+      },
+      jobs: Array.isArray(parsed.jobs) ? parsed.jobs : []
+    };
+  } catch {
+    return defaultState();
+  }
+}
+
+function pruneJobs(jobs) {
+  return [...jobs]
+    .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")))
+    .slice(0, MAX_JOBS);
+}
+
+function removeFileIfExists(filePath) {
+  if (filePath && fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+}
+
+export function saveState(cwd, state) {
+  const previousJobs = loadState(cwd).jobs;
+  ensureStateDir(cwd);
+  const nextJobs = pruneJobs(state.jobs ?? []);
+  const nextState = {
+    version: STATE_VERSION,
+    config: {
+      ...defaultState().config,
+      ...(state.config ?? {})
+    },
+    jobs: nextJobs
+  };
+
+  const retainedIds = new Set(nextJobs.map((job) => job.id));
+  for (const job of previousJobs) {
+    if (retainedIds.has(job.id)) {
+      continue;
+    }
+    removeJobFile(resolveJobFile(cwd, job.id));
+    removeFileIfExists(job.logFile);
+  }
+
+  fs.writeFileSync(resolveStateFile(cwd), `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  return nextState;
+}
+
+export function updateState(cwd, mutate) {
+  const state = loadState(cwd);
+  mutate(state);
+  return saveState(cwd, state);
+}
+
+export function generateJobId(prefix = "job") {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${Date.now().toString(36)}-${random}`;
+}
+
+export function upsertJob(cwd, jobPatch) {
+  return updateState(cwd, (state) => {
+    const timestamp = nowIso();
+    const existingIndex = state.jobs.findIndex((job) => job.id === jobPatch.id);
+    if (existingIndex === -1) {
+      state.jobs.unshift({
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        ...jobPatch
+      });
+      return;
+    }
+    state.jobs[existingIndex] = {
+      ...state.jobs[existingIndex],
+      ...jobPatch,
+      updatedAt: timestamp
+    };
+  });
+}
+
+export function listJobs(cwd) {
+  return loadState(cwd).jobs;
+}
+
+export function setConfig(cwd, key, value) {
+  return updateState(cwd, (state) => {
+    state.config = {
+      ...state.config,
+      [key]: value
+    };
+  });
+}
+
+export function getConfig(cwd) {
+  return loadState(cwd).config;
+}
+
+export function writeJobFile(cwd, jobId, payload) {
+  ensureStateDir(cwd);
+  const jobFile = resolveJobFile(cwd, jobId);
+  fs.writeFileSync(jobFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return jobFile;
+}
+
+export function readJobFile(jobFile) {
+  return JSON.parse(fs.readFileSync(jobFile, "utf8"));
+}
+
+function removeJobFile(jobFile) {
+  if (fs.existsSync(jobFile)) {
+    fs.unlinkSync(jobFile);
+  }
+}
+
+export function resolveJobLogFile(cwd, jobId) {
+  ensureStateDir(cwd);
+  return path.join(resolveJobsDir(cwd), `${jobId}.log`);
+}
+
+export function resolveJobFile(cwd, jobId) {
+  ensureStateDir(cwd);
+  return path.join(resolveJobsDir(cwd), `${jobId}.json`);
+}

--- a/scripts/crew-codex/lib/tracked-jobs.mjs
+++ b/scripts/crew-codex/lib/tracked-jobs.mjs
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import process from "node:process";
 
-import { readJobFile, resolveJobFile, resolveJobLogFile, upsertJob, writeJobFile } from "./state.mjs";
+import { readJobFile, resolveJobFile, resolveJobLogFile, updateState, upsertJob, writeJobFile } from "./state.mjs";
 
 export const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
 
@@ -141,6 +141,58 @@ function readStoredJobOrNull(workspaceRoot, jobId) {
   return readJobFile(jobFile);
 }
 
+function updateActiveRunningJob(workspaceRoot, jobId, pid, patch) {
+  let updated = false;
+  updateState(workspaceRoot, (state) => {
+    const existingIndex = state.jobs.findIndex((candidate) => candidate.id === jobId);
+    if (existingIndex === -1) {
+      return;
+    }
+
+    const existing = state.jobs[existingIndex];
+    if (existing.status !== "running" || existing.pid !== pid) {
+      return;
+    }
+
+    state.jobs[existingIndex] = {
+      ...existing,
+      ...patch
+    };
+    updated = true;
+  });
+  return updated;
+}
+
+function markJobRunning(workspaceRoot, runningRecord) {
+  let updated = false;
+  updateState(workspaceRoot, (state) => {
+    const timestamp = nowIso();
+    const existingIndex = state.jobs.findIndex((candidate) => candidate.id === runningRecord.id);
+    if (existingIndex === -1) {
+      state.jobs.unshift({
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        ...runningRecord
+      });
+      updated = true;
+      return;
+    }
+
+    const existing = state.jobs[existingIndex];
+    if (existing.status !== "queued") {
+      return;
+    }
+
+    state.jobs[existingIndex] = {
+      ...existing,
+      ...runningRecord,
+      updatedAt: timestamp
+    };
+    updated = true;
+  });
+  return updated;
+}
+
 export async function runTrackedJob(job, runner, options = {}) {
   const runningRecord = {
     ...job,
@@ -150,13 +202,43 @@ export async function runTrackedJob(job, runner, options = {}) {
     pid: process.pid,
     logFile: options.logFile ?? job.logFile ?? null
   };
+  const started = markJobRunning(job.workspaceRoot, runningRecord);
+  if (!started) {
+    appendLogLine(options.logFile ?? job.logFile ?? null, "Job was no longer queued; skipping worker execution.");
+    return {
+      exitStatus: 1,
+      threadId: job.threadId ?? null,
+      turnId: job.turnId ?? null,
+      payload: {
+        status: 1,
+        errorMessage: "Job was no longer queued; skipping worker execution."
+      },
+      rendered: "Job was no longer queued; skipping worker execution.\n",
+      summary: "Job skipped because it was no longer queued."
+    };
+  }
   writeJobFile(job.workspaceRoot, job.id, runningRecord);
-  upsertJob(job.workspaceRoot, runningRecord);
 
   try {
     const execution = await runner();
     const completionStatus = execution.exitStatus === 0 ? "completed" : "failed";
     const completedAt = nowIso();
+    const completionPatch = {
+      status: completionStatus,
+      threadId: execution.threadId ?? null,
+      turnId: execution.turnId ?? null,
+      summary: execution.summary,
+      phase: completionStatus === "completed" ? "done" : "failed",
+      pid: null,
+      completedAt,
+      updatedAt: completedAt
+    };
+    const transitioned = updateActiveRunningJob(job.workspaceRoot, job.id, process.pid, completionPatch);
+    if (!transitioned) {
+      appendLogLine(options.logFile ?? job.logFile ?? null, "Job was no longer active at completion; preserving current job state.");
+      return execution;
+    }
+
     writeJobFile(job.workspaceRoot, job.id, {
       ...runningRecord,
       status: completionStatus,
@@ -168,22 +250,26 @@ export async function runTrackedJob(job, runner, options = {}) {
       result: execution.payload,
       rendered: execution.rendered
     });
-    upsertJob(job.workspaceRoot, {
-      id: job.id,
-      status: completionStatus,
-      threadId: execution.threadId ?? null,
-      turnId: execution.turnId ?? null,
-      summary: execution.summary,
-      phase: completionStatus === "completed" ? "done" : "failed",
-      pid: null,
-      completedAt
-    });
     appendLogBlock(options.logFile ?? job.logFile ?? null, "Final output", execution.rendered);
     return execution;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const existing = readStoredJobOrNull(job.workspaceRoot, job.id) ?? runningRecord;
     const completedAt = nowIso();
+    const failurePatch = {
+      status: "failed",
+      phase: "failed",
+      pid: null,
+      errorMessage,
+      completedAt,
+      updatedAt: completedAt
+    };
+    const transitioned = updateActiveRunningJob(job.workspaceRoot, job.id, process.pid, failurePatch);
+    if (!transitioned) {
+      appendLogLine(options.logFile ?? job.logFile ?? null, "Job was no longer active after failure; preserving current job state.");
+      throw error;
+    }
+
     writeJobFile(job.workspaceRoot, job.id, {
       ...existing,
       status: "failed",
@@ -192,14 +278,6 @@ export async function runTrackedJob(job, runner, options = {}) {
       pid: null,
       completedAt,
       logFile: options.logFile ?? job.logFile ?? existing.logFile ?? null
-    });
-    upsertJob(job.workspaceRoot, {
-      id: job.id,
-      status: "failed",
-      phase: "failed",
-      pid: null,
-      errorMessage,
-      completedAt
     });
     throw error;
   }

--- a/scripts/crew-codex/lib/tracked-jobs.mjs
+++ b/scripts/crew-codex/lib/tracked-jobs.mjs
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import process from "node:process";
 
-import { readJobFile, resolveJobFile, resolveJobLogFile, updateState, upsertJob, writeJobFile } from "./state.mjs";
+import { readJobFile, resolveJobFile, resolveJobLogFile, updateJobStateAndFile } from "./state.mjs";
 
 export const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
 
@@ -101,17 +101,24 @@ export function createJobProgressUpdater(workspaceRoot, jobId) {
       return;
     }
 
-    upsertJob(workspaceRoot, patch);
+    updateJobStateAndFile(workspaceRoot, jobId, (existing) => {
+      if (!existing || existing.status === "completed" || existing.status === "failed" || existing.status === "cancelled") {
+        return null;
+      }
 
-    const jobFile = resolveJobFile(workspaceRoot, jobId);
-    if (!fs.existsSync(jobFile)) {
-      return;
-    }
-
-    const storedJob = readJobFile(jobFile);
-    writeJobFile(workspaceRoot, jobId, {
-      ...storedJob,
-      ...patch
+      const jobFile = resolveJobFile(workspaceRoot, jobId);
+      const storedJob = fs.existsSync(jobFile) ? readJobFile(jobFile) : existing;
+      return {
+        stateJob: {
+          ...patch,
+          phase: patch.phase ?? existing.phase
+        },
+        fileJob: {
+          ...storedJob,
+          ...patch,
+          phase: patch.phase ?? storedJob.phase
+        }
+      };
     });
   };
 }
@@ -141,56 +148,35 @@ function readStoredJobOrNull(workspaceRoot, jobId) {
   return readJobFile(jobFile);
 }
 
-function updateActiveRunningJob(workspaceRoot, jobId, pid, patch) {
-  let updated = false;
-  updateState(workspaceRoot, (state) => {
-    const existingIndex = state.jobs.findIndex((candidate) => candidate.id === jobId);
-    if (existingIndex === -1) {
-      return;
+function updateActiveRunningJob(workspaceRoot, jobId, pid, patch, fileJob = null) {
+  const updated = updateJobStateAndFile(workspaceRoot, jobId, (existing) => {
+    if (!existing || existing.status !== "running" || existing.pid !== pid) {
+      return null;
     }
 
-    const existing = state.jobs[existingIndex];
-    if (existing.status !== "running" || existing.pid !== pid) {
-      return;
-    }
-
-    state.jobs[existingIndex] = {
-      ...existing,
-      ...patch
+    return {
+      stateJob: patch,
+      ...(fileJob ? { fileJob } : {})
     };
-    updated = true;
   });
-  return updated;
+  return Boolean(updated);
 }
 
 function markJobRunning(workspaceRoot, runningRecord) {
-  let updated = false;
-  updateState(workspaceRoot, (state) => {
-    const timestamp = nowIso();
-    const existingIndex = state.jobs.findIndex((candidate) => candidate.id === runningRecord.id);
-    if (existingIndex === -1) {
-      state.jobs.unshift({
-        createdAt: timestamp,
-        updatedAt: timestamp,
-        ...runningRecord
-      });
-      updated = true;
-      return;
+  const updated = updateJobStateAndFile(workspaceRoot, runningRecord.id, (existing, { timestamp }) => {
+    if (existing && existing.status !== "queued") {
+      return null;
     }
 
-    const existing = state.jobs[existingIndex];
-    if (existing.status !== "queued") {
-      return;
-    }
-
-    state.jobs[existingIndex] = {
-      ...existing,
-      ...runningRecord,
-      updatedAt: timestamp
+    return {
+      stateJob: {
+        ...runningRecord,
+        updatedAt: timestamp
+      },
+      fileJob: runningRecord
     };
-    updated = true;
   });
-  return updated;
+  return Boolean(updated);
 }
 
 export async function runTrackedJob(job, runner, options = {}) {
@@ -217,7 +203,6 @@ export async function runTrackedJob(job, runner, options = {}) {
       summary: "Job skipped because it was no longer queued."
     };
   }
-  writeJobFile(job.workspaceRoot, job.id, runningRecord);
 
   try {
     const execution = await runner();
@@ -233,13 +218,7 @@ export async function runTrackedJob(job, runner, options = {}) {
       completedAt,
       updatedAt: completedAt
     };
-    const transitioned = updateActiveRunningJob(job.workspaceRoot, job.id, process.pid, completionPatch);
-    if (!transitioned) {
-      appendLogLine(options.logFile ?? job.logFile ?? null, "Job was no longer active at completion; preserving current job state.");
-      return execution;
-    }
-
-    writeJobFile(job.workspaceRoot, job.id, {
+    const completedFileJob = {
       ...runningRecord,
       status: completionStatus,
       threadId: execution.threadId ?? null,
@@ -249,7 +228,18 @@ export async function runTrackedJob(job, runner, options = {}) {
       completedAt,
       result: execution.payload,
       rendered: execution.rendered
-    });
+    };
+    const transitioned = updateActiveRunningJob(
+      job.workspaceRoot,
+      job.id,
+      process.pid,
+      completionPatch,
+      completedFileJob
+    );
+    if (!transitioned) {
+      appendLogLine(options.logFile ?? job.logFile ?? null, "Job was no longer active at completion; preserving current job state.");
+      return execution;
+    }
     appendLogBlock(options.logFile ?? job.logFile ?? null, "Final output", execution.rendered);
     return execution;
   } catch (error) {
@@ -264,13 +254,7 @@ export async function runTrackedJob(job, runner, options = {}) {
       completedAt,
       updatedAt: completedAt
     };
-    const transitioned = updateActiveRunningJob(job.workspaceRoot, job.id, process.pid, failurePatch);
-    if (!transitioned) {
-      appendLogLine(options.logFile ?? job.logFile ?? null, "Job was no longer active after failure; preserving current job state.");
-      throw error;
-    }
-
-    writeJobFile(job.workspaceRoot, job.id, {
+    const failedFileJob = {
       ...existing,
       status: "failed",
       phase: "failed",
@@ -278,7 +262,18 @@ export async function runTrackedJob(job, runner, options = {}) {
       pid: null,
       completedAt,
       logFile: options.logFile ?? job.logFile ?? existing.logFile ?? null
-    });
+    };
+    const transitioned = updateActiveRunningJob(
+      job.workspaceRoot,
+      job.id,
+      process.pid,
+      failurePatch,
+      failedFileJob
+    );
+    if (!transitioned) {
+      appendLogLine(options.logFile ?? job.logFile ?? null, "Job was no longer active after failure; preserving current job state.");
+      throw error;
+    }
     throw error;
   }
 }

--- a/scripts/crew-codex/lib/tracked-jobs.mjs
+++ b/scripts/crew-codex/lib/tracked-jobs.mjs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import fs from "node:fs";
+import process from "node:process";
+
+import { readJobFile, resolveJobFile, resolveJobLogFile, upsertJob, writeJobFile } from "./state.mjs";
+
+export const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
+
+export function nowIso() {
+  return new Date().toISOString();
+}
+
+function normalizeProgressEvent(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return {
+      message: String(value.message ?? "").trim(),
+      phase: typeof value.phase === "string" && value.phase.trim() ? value.phase.trim() : null,
+      threadId: typeof value.threadId === "string" && value.threadId.trim() ? value.threadId.trim() : null,
+      turnId: typeof value.turnId === "string" && value.turnId.trim() ? value.turnId.trim() : null,
+      stderrMessage: value.stderrMessage == null ? null : String(value.stderrMessage).trim(),
+      logTitle: typeof value.logTitle === "string" && value.logTitle.trim() ? value.logTitle.trim() : null,
+      logBody: value.logBody == null ? null : String(value.logBody).trimEnd()
+    };
+  }
+
+  return {
+    message: String(value ?? "").trim(),
+    phase: null,
+    threadId: null,
+    turnId: null,
+    stderrMessage: String(value ?? "").trim(),
+    logTitle: null,
+    logBody: null
+  };
+}
+
+export function appendLogLine(logFile, message) {
+  const normalized = String(message ?? "").trim();
+  if (!logFile || !normalized) {
+    return;
+  }
+  fs.appendFileSync(logFile, `[${nowIso()}] ${normalized}\n`, "utf8");
+}
+
+export function appendLogBlock(logFile, title, body) {
+  if (!logFile || !body) {
+    return;
+  }
+  fs.appendFileSync(logFile, `\n[${nowIso()}] ${title}\n${String(body).trimEnd()}\n`, "utf8");
+}
+
+export function createJobLogFile(workspaceRoot, jobId, title) {
+  const logFile = resolveJobLogFile(workspaceRoot, jobId);
+  fs.writeFileSync(logFile, "", "utf8");
+  if (title) {
+    appendLogLine(logFile, `Starting ${title}.`);
+  }
+  return logFile;
+}
+
+export function createJobRecord(base, options = {}) {
+  const env = options.env ?? process.env;
+  const sessionId = env[options.sessionIdEnv ?? SESSION_ID_ENV];
+  return {
+    ...base,
+    createdAt: nowIso(),
+    ...(sessionId ? { sessionId } : {})
+  };
+}
+
+export function createJobProgressUpdater(workspaceRoot, jobId) {
+  let lastPhase = null;
+  let lastThreadId = null;
+  let lastTurnId = null;
+
+  return (event) => {
+    const normalized = normalizeProgressEvent(event);
+    const patch = { id: jobId };
+    let changed = false;
+
+    if (normalized.phase && normalized.phase !== lastPhase) {
+      lastPhase = normalized.phase;
+      patch.phase = normalized.phase;
+      changed = true;
+    }
+
+    if (normalized.threadId && normalized.threadId !== lastThreadId) {
+      lastThreadId = normalized.threadId;
+      patch.threadId = normalized.threadId;
+      changed = true;
+    }
+
+    if (normalized.turnId && normalized.turnId !== lastTurnId) {
+      lastTurnId = normalized.turnId;
+      patch.turnId = normalized.turnId;
+      changed = true;
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    upsertJob(workspaceRoot, patch);
+
+    const jobFile = resolveJobFile(workspaceRoot, jobId);
+    if (!fs.existsSync(jobFile)) {
+      return;
+    }
+
+    const storedJob = readJobFile(jobFile);
+    writeJobFile(workspaceRoot, jobId, {
+      ...storedJob,
+      ...patch
+    });
+  };
+}
+
+export function createProgressReporter({ stderr = false, logFile = null, onEvent = null } = {}) {
+  if (!stderr && !logFile && !onEvent) {
+    return null;
+  }
+
+  return (eventOrMessage) => {
+    const event = normalizeProgressEvent(eventOrMessage);
+    const stderrMessage = event.stderrMessage ?? event.message;
+    if (stderr && stderrMessage) {
+      process.stderr.write(`[codex] ${stderrMessage}\n`);
+    }
+    appendLogLine(logFile, event.message);
+    appendLogBlock(logFile, event.logTitle, event.logBody);
+    onEvent?.(event);
+  };
+}
+
+function readStoredJobOrNull(workspaceRoot, jobId) {
+  const jobFile = resolveJobFile(workspaceRoot, jobId);
+  if (!fs.existsSync(jobFile)) {
+    return null;
+  }
+  return readJobFile(jobFile);
+}
+
+export async function runTrackedJob(job, runner, options = {}) {
+  const runningRecord = {
+    ...job,
+    status: "running",
+    startedAt: nowIso(),
+    phase: "starting",
+    pid: process.pid,
+    logFile: options.logFile ?? job.logFile ?? null
+  };
+  writeJobFile(job.workspaceRoot, job.id, runningRecord);
+  upsertJob(job.workspaceRoot, runningRecord);
+
+  try {
+    const execution = await runner();
+    const completionStatus = execution.exitStatus === 0 ? "completed" : "failed";
+    const completedAt = nowIso();
+    writeJobFile(job.workspaceRoot, job.id, {
+      ...runningRecord,
+      status: completionStatus,
+      threadId: execution.threadId ?? null,
+      turnId: execution.turnId ?? null,
+      pid: null,
+      phase: completionStatus === "completed" ? "done" : "failed",
+      completedAt,
+      result: execution.payload,
+      rendered: execution.rendered
+    });
+    upsertJob(job.workspaceRoot, {
+      id: job.id,
+      status: completionStatus,
+      threadId: execution.threadId ?? null,
+      turnId: execution.turnId ?? null,
+      summary: execution.summary,
+      phase: completionStatus === "completed" ? "done" : "failed",
+      pid: null,
+      completedAt
+    });
+    appendLogBlock(options.logFile ?? job.logFile ?? null, "Final output", execution.rendered);
+    return execution;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const existing = readStoredJobOrNull(job.workspaceRoot, job.id) ?? runningRecord;
+    const completedAt = nowIso();
+    writeJobFile(job.workspaceRoot, job.id, {
+      ...existing,
+      status: "failed",
+      phase: "failed",
+      errorMessage,
+      pid: null,
+      completedAt,
+      logFile: options.logFile ?? job.logFile ?? existing.logFile ?? null
+    });
+    upsertJob(job.workspaceRoot, {
+      id: job.id,
+      status: "failed",
+      phase: "failed",
+      pid: null,
+      errorMessage,
+      completedAt
+    });
+    throw error;
+  }
+}

--- a/scripts/crew-codex/lib/workspace.mjs
+++ b/scripts/crew-codex/lib/workspace.mjs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Derived from @openai/codex-plugin-cc and modified for claude-crew.
+import { ensureGitRepository } from "./git.mjs";
+
+export function resolveWorkspaceRoot(cwd) {
+  try {
+    return ensureGitRepository(cwd);
+  } catch {
+    return cwd;
+  }
+}

--- a/skills/crew-dev/SKILL.md
+++ b/skills/crew-dev/SKILL.md
@@ -43,7 +43,7 @@ Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")
 
 **codex provider:**
 ```
-Bash("node \"${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs\" task {writeFlag} --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}")
+Bash("node \"${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs\" task --json {writeFlag} --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}")
 ```
 - 프롬프트는 임시 파일에 저장하고 `--prompt-file`로 전달한다.
 - `writeFlag`는 `data/provider-catalog.json`의 `agent_runtime.{role}.codex_sandbox`가 `workspace-write`일 때만 `--write`로 설정한다. 기본값은 read-only이며 `dev`만 workspace-write다.
@@ -326,7 +326,7 @@ US-{k}에 해당하는 피드백만 수정한다. 다른 US의 코드를 변경�
 오케스트레이터가 plan.md에서 US-{k} 섹션과 contract.md의 수용 기준을 추출하여 프롬프트에 인라인으로 주입한다.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --write --expect-crew-result --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
+node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --write --expect-crew-result --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
 ```
 
 `{promptFile}` 내용:
@@ -527,7 +527,7 @@ contract.md, brief.md, spec.md는 읽지 않는다.
 Codex provider인 CodeReviewer/QA는 read-only로 실행한다. `--write`를 붙이지 않는다.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --expect-crew-result --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
+node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
 ```
 
 CodeReviewer/QA Codex 프롬프트도 마지막에 `<crew-agent-result>` 블록을 포함해야 한다. 검토/검증 결과는 `artifact`에 넣고, 판정이 불가능하면 `failed` 또는 `needs_tool`을 반환한다.

--- a/skills/crew-dev/SKILL.md
+++ b/skills/crew-dev/SKILL.md
@@ -43,9 +43,10 @@ Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")
 
 **codex provider:**
 ```
-Bash("node \"${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs\" task --write --model {model} --effort {reasoning} --prompt-file {promptFile}")
+Bash("node \"${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs\" task {writeFlag} --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}")
 ```
 - 프롬프트는 임시 파일에 저장하고 `--prompt-file`로 전달한다.
+- `writeFlag`는 `data/provider-catalog.json`의 `agent_runtime.{role}.codex_sandbox`가 `workspace-write`일 때만 `--write`로 설정한다. 기본값은 read-only이며 `dev`만 workspace-write다.
 - Codex는 CWD 기준으로 작업하므로 워크트리 안에서 실행한다.
 - Codex app-server thread id와 stdout에서 결과를 캡처한다.
 - 같은 Codex 작업을 이어갈 때는 `--resume-last`를 사용한다.
@@ -54,6 +55,35 @@ Bash("node \"${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs\" task --wri
 - Codex는 Claude Code의 Read/Edit/Glob 도구가 아닌 자체 도구를 사용한다.
 - Codex 에이전트는 `.crew/` 접근 정책을 우회하면 안 된다. 필요한 `.crew/` 내용은 오케스트레이터가 프롬프트에 인라인으로 주입한다.
 - Codex dev-log.md 작성: Codex stdout을 오케스트레이터가 파싱하여 dev-log.md를 생성한다.
+
+### AgentResult 공통 프로토콜
+
+Codex provider를 사용하는 모든 에이전트는 마지막에 아래 블록을 반드시 출력한다. 오케스트레이터는 `--expect-crew-result` payload의 `crewAgentResult`를 파싱하여 상태별 후속 액션을 수행한다.
+
+```json
+<crew-agent-result>
+{
+  "status": "complete",
+  "artifact": "에이전트 최종 결과 또는 산출물",
+  "questions": [],
+  "requests": [],
+  "summary": "짧은 요약",
+  "error": null
+}
+</crew-agent-result>
+```
+
+허용 상태:
+- `complete`: `artifact`를 저장하거나 다음 단계로 전달한다.
+- `blocked_on_user`: `questions`를 `AskUserQuestion`으로 질문한 뒤 같은 에이전트를 `--resume-last`로 이어간다.
+- `needs_agent`: `requests`의 `role`/`prompt`를 `runAgent`로 실행한 뒤 결과를 같은 에이전트에 주입한다.
+- `needs_tool`: 오케스트레이터가 허용된 Claude Code 도구를 실행한 뒤 결과를 같은 에이전트에 주입한다.
+- `failed`: crash/retry/fallback/escalation 정책을 적용한다.
+
+루프 상한:
+- 한 에이전트 실행당 AgentResult 후속 루프는 최대 5회.
+- 유저 질문은 한 에이전트 실행당 최대 3회.
+- `needs_agent` 요청은 한 에이전트 실행당 최대 5개.
 
 ---
 
@@ -113,13 +143,13 @@ Bash("node \"${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs\" task --wri
 
 **1a. Provider 설정 로드**
 
-1. `data/provider-catalog.json`을 읽어 `agent_defaults`를 로드한다.
+1. `data/provider-catalog.json`을 읽어 `agent_defaults`와 `agent_runtime`을 로드한다.
 2. `~/.claude/crew/config.json`이 있으면 `providers` 필드를 읽어 `agent_defaults`를 오버라이드한다 (유저 레벨).
 3. `{projectRoot}/.crew/config.json`이 있으면 `providers` 필드를 읽어 다시 오버라이드한다 (프로젝트 레벨, 최우선).
 4. codex provider가 하나라도 설정되어 있으면 `which codex`로 가용성을 확인한다.
    - codex가 없으면 경고를 출력하고 해당 에이전트를 Claude provider의 에이전트 frontmatter 모델로 폴백한다.
 
-해석된 설정을 Phase 2, 3에서 ��용한다.
+해석된 provider/model 설정과 role별 runtime 정책을 Phase 2, 3에서 사용한다.
 
 **1b. contract.md 유효성 검사**
 
@@ -296,7 +326,7 @@ US-{k}에 해당하는 피드백만 수정한다. 다른 US의 코드를 변경�
 오케스트레이터가 plan.md에서 US-{k} 섹션과 contract.md의 수용 기준을 추출하여 프롬프트에 인라인으로 주입한다.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --write --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
+node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --write --expect-crew-result --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
 ```
 
 `{promptFile}` 내용:
@@ -325,10 +355,18 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --write --mod
 - 기존 코드베이스의 컨벤션을 따른다.
 
 ## 완료 시 출력
-구현 요약을 출력하라:
-- 변경한 파일 목록
-- US-{k} 구현 내용 1줄 요약
-- 자체 검증 결과 (각 항목별 PASS/FAIL + 명령어 + 출력)
+구현 요약을 출력하고, 마지막에 `<crew-agent-result>` 블록을 포함하라:
+
+<crew-agent-result>
+{
+  "status": "complete",
+  "artifact": "변경한 파일 목록, US-{k} 구현 요약, 자체 검증 결과",
+  "questions": [],
+  "requests": [],
+  "summary": "US-{k} 구현 완료",
+  "error": null
+}
+</crew-agent-result>
 ```
 
 Codex stdout을 캡처하여 dev-log.md의 US-{k} 섹션으로 추가한다.
@@ -485,6 +523,14 @@ contract.md, brief.md, spec.md는 읽지 않는다.
 ```
 
 **병렬 실행 방법**: Phase 3과 동일 (provider 조합에 따라 Agent/Bash 병렬 호출).
+
+Codex provider인 CodeReviewer/QA는 read-only로 실행한다. `--write`를 붙이지 않는다.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --expect-crew-result --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
+```
+
+CodeReviewer/QA Codex 프롬프트도 마지막에 `<crew-agent-result>` 블록을 포함해야 한다. 검토/검증 결과는 `artifact`에 넣고, 판정이 불가능하면 `failed` 또는 `needs_tool`을 반환한다.
 
 **결과 저장 (오케스트레이터 직접)**:
 - CodeReviewer 결과 → `.crew/plans/{task-id}/review-report.md`
@@ -679,7 +725,7 @@ CodeReviewer와 QA 에이전트는 read-only이므로 파일을 직접 작성하
 오케스트레이터는 CodeReviewer와 QA를 **동시에** 호출한다. provider 조합에 따라:
 
 - 둘 다 claude → Agent tool 2개를 한 번에 호출
-- 둘 다 codex → Bash tool 2개를 한 번에 호출
+- 둘 다 codex → read-only Bash tool 2개를 한 번에 호출 (`--write` 금지)
 - 혼합 → Agent + Bash를 한 번에 호출
 
 ---

--- a/skills/crew-dev/SKILL.md
+++ b/skills/crew-dev/SKILL.md
@@ -43,15 +43,16 @@ Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")
 
 **codex provider:**
 ```
-Bash("codex exec --model {model} -c model_reasoning_effort=\"{reasoning}\" --dangerously-bypass-approvals-and-sandbox \"{prompt}\" < /dev/null")
+Bash("node \"${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs\" task --write --model {model} --effort {reasoning} --prompt-file {promptFile}")
 ```
-- 프롬프트가 길면 임시 파일에 저장 후 `cat`으로 전달한다.
+- 프롬프트는 임시 파일에 저장하고 `--prompt-file`로 전달한다.
 - Codex는 CWD 기준으로 작업하므로 워크트리 안에서 실행한다.
-- Codex의 stdout에서 결과를 캡처한다.
+- Codex app-server thread id와 stdout에서 결과를 캡처한다.
+- 같은 Codex 작업을 이어갈 때는 `--resume-last`를 사용한다.
 
 **codex provider 제약:**
 - Codex는 Claude Code의 Read/Edit/Glob 도구가 아닌 자체 도구를 사용한다.
-- Codex 에이전트는 `.crew/` 파일에 직접 접근할 수 없으므로, 프롬프트에 필요한 내용을 인라인으로 주입해야 한다.
+- Codex 에이전트는 `.crew/` 접근 정책을 우회하면 안 된다. 필요한 `.crew/` 내용은 오케스트레이터가 프롬프트에 인라인으로 주입한다.
 - Codex dev-log.md 작성: Codex stdout을 오케스트레이터가 파싱하여 dev-log.md를 생성한다.
 
 ---
@@ -116,7 +117,7 @@ Bash("codex exec --model {model} -c model_reasoning_effort=\"{reasoning}\" --dan
 2. `~/.claude/crew/config.json`이 있으면 `providers` 필드를 읽어 `agent_defaults`를 오버라이드한다 (유저 레벨).
 3. `{projectRoot}/.crew/config.json`이 있으면 `providers` 필드를 읽어 다시 오버라이드한다 (프로젝트 레벨, 최우선).
 4. codex provider가 하나라도 설정되어 있으면 `which codex`로 가용성을 확인한다.
-   - codex가 없으면 경고를 출력하고 해당 에이전트를 기본값(claude)으로 폴백한다.
+   - codex가 없으면 경고를 출력하고 해당 에이전트를 Claude provider의 에이전트 frontmatter 모델로 폴백한다.
 
 해석된 설정을 Phase 2, 3에서 ��용한다.
 
@@ -295,7 +296,12 @@ US-{k}에 해당하는 피드백만 수정한다. 다른 US의 코드를 변경�
 오케스트레이터가 plan.md에서 US-{k} 섹션과 contract.md의 수용 기준을 추출하여 프롬프트에 인라인으로 주입한다.
 
 ```bash
-codex exec --model {model} -c model_reasoning_effort="{reasoning}" --dangerously-bypass-approvals-and-sandbox "$(cat <<'PROMPT'
+node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --write --model {model} --effort "{reasoning}" --prompt-file "{promptFile}"
+```
+
+`{promptFile}` 내용:
+
+```markdown
 당신은 Dev 에이전트다. 아래 유저 스토리 US-{k}만 구현한다.
 
 ## US-{k} (plan.md에서 추출)
@@ -323,8 +329,6 @@ codex exec --model {model} -c model_reasoning_effort="{reasoning}" --dangerously
 - 변경한 파일 목록
 - US-{k} 구현 내용 1줄 요약
 - 자체 검증 결과 (각 항목별 PASS/FAIL + 명령어 + 출력)
-PROMPT
-)" < /dev/null
 ```
 
 Codex stdout을 캡처하여 dev-log.md의 US-{k} 섹션으로 추가한다.

--- a/skills/crew-interview/SKILL.md
+++ b/skills/crew-interview/SKILL.md
@@ -299,12 +299,12 @@ spec.md를 작성했습니다. 검토해주세요.
 
 ## 에이전트 호출 규칙
 
-| 에이전트 | subagent_type | 모델 | 용도 | 호출 시점 |
+| 에이전트 | subagent_type | 기본 provider/model | 용도 | 호출 시점 |
 |----------|--------------|------|------|----------|
-| Explorer | explorer | haiku | 코드베이스 탐색 (read-only) | Phase 1b (필수), Phase 2d (필요 시) |
-| Researcher | researcher | sonnet | 외부 조사 (WebSearch) | Phase 2 중 필요 시 |
+| Explorer | explorer | `agent_defaults.explorer` | 코드베이스 탐색 (read-only) | Phase 1b (필수), Phase 2d (필요 시) |
+| Researcher | researcher | `agent_defaults.researcher` | 외부 조사 (WebSearch) | Phase 2 중 필요 시 |
 
-**중요**: 모든 에이전트 호출 시 반드시 `subagent_type` 파라미터를 지정해야 한다. `subagent_type`이 없으면 PreToolUse hook이 호출을 차단한다. `model` 파라미터는 생략 가능 — hook이 에이전트 정의에서 자동 주입한다.
+**중요**: provider/model은 `.crew/config.json`, `~/.claude/crew/config.json`, `data/provider-catalog.json`의 `agent_defaults` 순서로 해석한다.
 
 ---
 

--- a/skills/crew-interview/SKILL.md
+++ b/skills/crew-interview/SKILL.md
@@ -34,6 +34,12 @@ description: 유저 요구사항을 인터뷰하여 개발 가능한 수준의 s
 
 ## 실행 순서
 
+PM 판단/질문/spec 작성 단계도 provider 설정 대상이다. 오케스트레이터는 `pm` 설정을 해석한 뒤 아래 인터뷰 로직을 PM 작업 프롬프트로 구성하여 `runAgent(role="pm", ...)`로 실행한다.
+
+- PM이 Claude provider이면 기존처럼 `AskUserQuestion`, Read/Write를 사용할 수 있다.
+- PM이 Codex provider이면 직접 질문하거나 `.crew/` 파일을 쓰지 않는다. 질문이 필요하면 `blocked_on_user`, 추가 탐색이 필요하면 `needs_agent`, 최종 spec은 `complete.artifact`로 반환한다.
+- Codex PM의 `artifact`는 오케스트레이터가 `.crew/plans/{task-id}/spec.md`로 저장한다.
+
 ### Phase 1 — 초기화 (자동)
 
 **1a. task-id 생성 + brief.md 작성**
@@ -46,7 +52,7 @@ task-id는 요청 내용에서 키워드를 추출하여 kebab-case로 생성한
 Explorer 서브에이전트를 병렬로 호출하여 프로젝트 구조를 파악한다.
 
 ```
-Agent(subagent_type="explorer", description="프로젝트 구조 탐색", prompt="...")
+runAgent(role="explorer", description="프로젝트 구조 탐색", prompt="...")
 ```
 
 탐색 목적:
@@ -124,7 +130,7 @@ NO 항목 중 **가장 선행되어야 할 것**을 선택한다.
 예: 유저가 "기존 결제 로직에 추가"라고 답하면 결제 관련 코드를 탐색.
 
 ```
-Agent(subagent_type="explorer", description="결제 관련 코드 탐색", prompt="...")
+runAgent(role="explorer", description="결제 관련 코드 탐색", prompt="...")
 ```
 
 **2e. 유저 답변 수신 + 큰 기획 갭 감지**
@@ -299,12 +305,34 @@ spec.md를 작성했습니다. 검토해주세요.
 
 ## 에이전트 호출 규칙
 
+오케스트레이터는 모든 에이전트를 `runAgent(role, prompt, providerConfig)` 규칙으로 호출한다.
+
+- Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
+- Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`
+- `data/provider-catalog.json`의 `agent_runtime.{role}.codex_sandbox`가 `workspace-write`일 때만 `--write`를 붙인다. interview 단계 에이전트는 모두 read-only다.
+- Codex provider는 `.crew/` 파일을 직접 읽거나 쓰지 않는다. 필요한 컨텍스트는 오케스트레이터가 프롬프트에 인라인 주입하고, 산출물은 `artifact`로 반환받아 오케스트레이터가 저장한다.
+
 | 에이전트 | subagent_type | 기본 provider/model | 용도 | 호출 시점 |
 |----------|--------------|------|------|----------|
 | Explorer | explorer | `agent_defaults.explorer` | 코드베이스 탐색 (read-only) | Phase 1b (필수), Phase 2d (필요 시) |
 | Researcher | researcher | `agent_defaults.researcher` | 외부 조사 (WebSearch) | Phase 2 중 필요 시 |
 
 **중요**: provider/model은 `.crew/config.json`, `~/.claude/crew/config.json`, `data/provider-catalog.json`의 `agent_defaults` 순서로 해석한다.
+
+Codex provider 결과는 마지막 `<crew-agent-result>` 블록으로 파싱한다.
+
+```json
+{
+  "status": "complete | blocked_on_user | needs_agent | needs_tool | failed",
+  "artifact": "최종 산출물 또는 결과",
+  "questions": [],
+  "requests": [],
+  "summary": "짧은 요약",
+  "error": null
+}
+```
+
+`blocked_on_user`는 오케스트레이터가 `AskUserQuestion`으로 처리하고, `needs_agent`는 요청된 role을 다시 `runAgent`로 실행한 뒤 결과를 원래 에이전트에 `--resume-last`로 주입한다.
 
 ---
 

--- a/skills/crew-interview/SKILL.md
+++ b/skills/crew-interview/SKILL.md
@@ -308,7 +308,7 @@ spec.md를 작성했습니다. 검토해주세요.
 오케스트레이터는 모든 에이전트를 `runAgent(role, prompt, providerConfig)` 규칙으로 호출한다.
 
 - Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
-- Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`
+- Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`
 - `data/provider-catalog.json`의 `agent_runtime.{role}.codex_sandbox`가 `workspace-write`일 때만 `--write`를 붙인다. interview 단계 에이전트는 모두 read-only다.
 - Codex provider는 `.crew/` 파일을 직접 읽거나 쓰지 않는다. 필요한 컨텍스트는 오케스트레이터가 프롬프트에 인라인 주입하고, 산출물은 `artifact`로 반환받아 오케스트레이터가 저장한다.
 

--- a/skills/crew-plan/SKILL.md
+++ b/skills/crew-plan/SKILL.md
@@ -495,7 +495,7 @@ Planner + PlanEvaluator 사이클은 최대 5회 (초기 1회 + retry 최대 4�
 오케스트레이터는 모든 에이전트를 `runAgent(role, prompt, providerConfig)` 규칙으로 호출한다.
 
 - Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
-- Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`
+- Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`
 - `data/provider-catalog.json`의 `agent_runtime.{role}.codex_sandbox`가 `workspace-write`일 때만 `--write`를 붙인다. plan 단계 에이전트는 모두 read-only다.
 - Codex provider는 `.crew/` 파일을 직접 읽거나 쓰지 않는다. 필요한 `spec.md`, `analysis.md`, `plan.md`, `review-{n}.md` 내용은 오케스트레이터가 프롬프트에 인라인 주입한다.
 

--- a/skills/crew-plan/SKILL.md
+++ b/skills/crew-plan/SKILL.md
@@ -40,6 +40,12 @@ crew-interview가 생성한 spec.md를 입력으로 받아 **HOW(어떻게 만�
 
 ## 실행 순서
 
+TechLead, Planner, PlanEvaluator는 모두 provider 설정 대상이다. 오케스트레이터는 각 단계에서 `runAgent(role, prompt, providerConfig)`를 사용한다.
+
+- Claude provider이면 기존 Claude Code `Agent` 호출을 사용한다.
+- Codex provider이면 read-only companion task를 사용하고, 산출물은 `<crew-agent-result>.artifact`로 반환받아 오케스트레이터가 `.crew/` 파일에 저장한다.
+- Codex TechLead/Planner가 Explorer/Researcher가 필요하면 직접 호출하지 않고 `needs_agent`를 반환한다. 오케스트레이터가 요청된 에이전트를 실행한 뒤 결과를 원래 Codex thread에 `--resume-last`로 주입한다.
+
 ### Step 1 — spec.md 유효성 검사 (오케스트레이터 직접)
 
 `.crew/plans/{task-id}/spec.md`를 확인한다.
@@ -60,7 +66,7 @@ spec.md가 없거나 비어 있습니다. crew-interview를 먼저 실행해야 
 
 **provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.techlead`).
 
-호출:
+Claude provider 호출 예:
 
 ```
 Agent(subagent_type="techlead", description="TechLead: {task-id} 사전 분석", prompt="...")
@@ -79,14 +85,14 @@ WHAT(무엇을 만드는가)은 이미 정의되어 있으므로, HOW(어떻게 
 
 ## 서브에이전트 호출
 - Explorer (Haiku): 코드베이스 탐색. 항상 호출. 병렬 2-3개로 호출하라.
-  Agent(subagent_type="explorer", description="코드베이스 탐색: {탐색 대상}", prompt="...")
+  runAgent(role="explorer", description="코드베이스 탐색: {탐색 대상}", prompt="...")
   **필수 탐색 항목**: 테스트 인프라도 반드시 탐색한다. Explorer 중 1개는 다음을 확인:
   - 테스트 프레임워크 설정 파일 (jest.config.*, vitest.config.*, pytest.ini 등)
   - 대표적인 테스트 파일 2-3개의 패턴
   - 커버리지 설정 여부
   - 테스트 실행 스크립트 (package.json scripts 등)
 - Researcher (Sonnet): 외부 리서치. 필요시만 호출.
-  Agent(subagent_type="researcher", description="외부 리서치: {리서치 대상}", prompt="...")
+  runAgent(role="researcher", description="외부 리서치: {리서치 대상}", prompt="...")
   **외부 API/서비스가 관련된 경우**: spec.md에 언급된 각 외부 대상(엔드포인트, 서비스, 플랫폼)에 대해 **개별적으로** 문서/인터페이스를 조사하라. 하나의 대상에 대한 문서를 다른 대상에 일반화하지 않는다. 문서가 확인되지 않는 대상은 "미검증 인터페이스"로 명시한다.
 
 ## 출력
@@ -154,7 +160,7 @@ TechLead의 analysis.md에서 테스트 인프라 섹션을 확인한 후, 오�
 
 **provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.planner`).
 
-호출:
+Claude provider 호출 예:
 
 ```
 Agent(subagent_type="planner", description="Planner: {task-id} 구현 계획", prompt="...")
@@ -260,7 +266,7 @@ plan.md 최상단에 "이전 피드백 반영" 섹션을 추가한다.
 
 **provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.plan-evaluator`).
 
-호출:
+Claude provider 호출 예:
 
 ```
 Agent(subagent_type="plan-evaluator", description="PlanEvaluator: {task-id} 계획 검증", prompt="...")
@@ -307,7 +313,7 @@ Agent(subagent_type="plan-evaluator", description="PlanEvaluator: {task-id} 계�
 
 ## E3 코드 참조 확인
 Explorer 서브에이전트를 호출하여 plan.md에서 참조하는 파일/모듈이 존재하는지 확인하라.
-Agent(subagent_type="explorer", description="코드 참조 확인: {파일 목록 요약}", prompt="plan.md에서 참조하는 다음 파일/모듈이 존재하는지 확인하라: {파일 목록}")
+runAgent(role="explorer", description="코드 참조 확인: {파일 목록 요약}", prompt="plan.md에서 참조하는 다음 파일/모듈이 존재하는지 확인하라: {파일 목록}")
 
 ## 출력
 아래 형식으로 검증 결과를 텍스트로 반환하라. 파일을 직접 작성하지 않는다.
@@ -486,6 +492,13 @@ Planner + PlanEvaluator 사이클은 최대 5회 (초기 1회 + retry 최대 4�
 
 ## 에이전트 호출 컨텍스트 규칙
 
+오케스트레이터는 모든 에이전트를 `runAgent(role, prompt, providerConfig)` 규칙으로 호출한다.
+
+- Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
+- Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`
+- `data/provider-catalog.json`의 `agent_runtime.{role}.codex_sandbox`가 `workspace-write`일 때만 `--write`를 붙인다. plan 단계 에이전트는 모두 read-only다.
+- Codex provider는 `.crew/` 파일을 직접 읽거나 쓰지 않는다. 필요한 `spec.md`, `analysis.md`, `plan.md`, `review-{n}.md` 내용은 오케스트레이터가 프롬프트에 인라인 주입한다.
+
 | 에이전트 | subagent_type | 기본 provider/model | 주입할 파일 | 차단할 파일 |
 |----------|--------------|------|------------|------------|
 | TechLead | techlead | `agent_defaults.techlead` | spec.md | — |
@@ -494,6 +507,21 @@ Planner + PlanEvaluator 사이클은 최대 5회 (초기 1회 + retry 최대 4�
 | PlanEvaluator | plan-evaluator | `agent_defaults.plan-evaluator` | spec.md + analysis.md + plan.md | brief.md |
 
 **중요**: provider/model은 `.crew/config.json`, `~/.claude/crew/config.json`, `data/provider-catalog.json`의 `agent_defaults` 순서로 해석한다. Claude provider는 `Agent(subagent_type=..., model=...)`로 호출하고, Codex provider는 `scripts/crew-codex-companion.mjs task`로 호출한다.
+
+Codex provider 결과는 마지막 `<crew-agent-result>` 블록으로 파싱한다.
+
+```json
+{
+  "status": "complete | blocked_on_user | needs_agent | needs_tool | failed",
+  "artifact": "최종 산출물 또는 결과",
+  "questions": [],
+  "requests": [],
+  "summary": "짧은 요약",
+  "error": null
+}
+```
+
+`blocked_on_user`는 오케스트레이터가 `AskUserQuestion`으로 처리한다. `needs_agent`는 Explorer/Researcher 등 요청된 role을 `runAgent`로 실행한 뒤 결과를 원래 에이전트에 `--resume-last`로 주입한다. 한 에이전트 실행의 후속 루프는 최대 5회다.
 
 ---
 

--- a/skills/crew-plan/SKILL.md
+++ b/skills/crew-plan/SKILL.md
@@ -58,7 +58,7 @@ spec.md가 없거나 비어 있습니다. crew-interview를 먼저 실행해야 
 
 ### Step 2 — TechLead 에이전트 실행
 
-**모델**: opus
+**provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.techlead`).
 
 호출:
 
@@ -152,7 +152,7 @@ TechLead의 analysis.md에서 테스트 인프라 섹션을 확인한 후, 오�
 
 ### Step 3 — Planner 에이전트 실행
 
-**모델**: opus
+**provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.planner`).
 
 호출:
 
@@ -258,7 +258,7 @@ plan.md 최상단에 "이전 피드백 반영" 섹션을 추가한다.
 
 ### Step 4 — PlanEvaluator 에이전트 실행
 
-**모델**: sonnet (하드 임계값 판정에서 Opus 합리화 방지)
+**provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.plan-evaluator`).
 
 호출:
 
@@ -486,14 +486,14 @@ Planner + PlanEvaluator 사이클은 최대 5회 (초기 1회 + retry 최대 4�
 
 ## 에이전트 호출 컨텍스트 규칙
 
-| 에이전트 | subagent_type | 모델 | 주입할 파일 | 차단할 파일 |
+| 에이전트 | subagent_type | 기본 provider/model | 주입할 파일 | 차단할 파일 |
 |----------|--------------|------|------------|------------|
-| TechLead | techlead | opus | spec.md | — |
-| Planner (첫 번째) | planner | opus | spec.md + analysis.md | brief.md |
-| Planner (retry) | planner | opus | spec.md + analysis.md + review-{n}.md | brief.md |
-| PlanEvaluator | plan-evaluator | sonnet | spec.md + analysis.md + plan.md | brief.md |
+| TechLead | techlead | `agent_defaults.techlead` | spec.md | — |
+| Planner (첫 번째) | planner | `agent_defaults.planner` | spec.md + analysis.md | brief.md |
+| Planner (retry) | planner | `agent_defaults.planner` | spec.md + analysis.md + review-{n}.md | brief.md |
+| PlanEvaluator | plan-evaluator | `agent_defaults.plan-evaluator` | spec.md + analysis.md + plan.md | brief.md |
 
-**중요**: 모든 에이전트 호출 시 반드시 `subagent_type` 파라미터를 지정해야 한다. `subagent_type`이 없으면 PreToolUse hook이 호출을 차단한다. `model` 파라미터는 생략 가능 — hook이 에이전트 정의에서 자동 주입한다.
+**중요**: provider/model은 `.crew/config.json`, `~/.claude/crew/config.json`, `data/provider-catalog.json`의 `agent_defaults` 순서로 해석한다. Claude provider는 `Agent(subagent_type=..., model=...)`로 호출하고, Codex provider는 `scripts/crew-codex-companion.mjs task`로 호출한다.
 
 ---
 

--- a/skills/crew-setup/SKILL.md
+++ b/skills/crew-setup/SKILL.md
@@ -147,7 +147,7 @@ git rev-parse --show-toplevel
 which codex
 ```
 
-- codex가 없으면: "Codex CLI가 설치되어 있지 않습니다. 모든 에이전트가 Claude를 사용합니다." 안내 후 Step 3를 스킵한다.
+- codex가 없으면: "Codex CLI가 설치되어 있지 않습니다. Codex provider 선택지는 표시하지 않습니다." 안내 후 Claude 모델만 설정한다.
 - codex가 있으면: 계속 진행한다.
 
 ### 3d. 기존 설정 표시
@@ -156,8 +156,14 @@ Step 3a에서 판별된 config 경로의 파일이 있으면 현재 설정을 �
 
 ```
 현재 에이전트 설정:
-  - dev: claude / opus (기본값)
-  - code-reviewer: claude / opus (기본값)
+  - pm: claude / opus (기본값)
+  - techlead: claude / opus (기본값)
+  - planner: claude / opus (기본값)
+  - plan-evaluator: claude / sonnet (기본값)
+  - explorer: claude / haiku (기본값)
+  - researcher: claude / sonnet (기본값)
+  - dev: codex / gpt-5.5 medium (기본값)
+  - code-reviewer: codex / gpt-5.5 medium (기본값)
   - qa: claude / sonnet (기본값)
 ```
 
@@ -167,46 +173,37 @@ Step 3a에서 판별된 config 경로의 파일이 있으면 현재 설정을 �
 
 ```
 설정을 변경할 에이전트를 선택하세요 (쉼표 구분, 엔터 = 스킵):
-  dev, code-reviewer, qa
+  pm, techlead, planner, plan-evaluator, explorer, researcher, dev, code-reviewer, qa
 ```
 
 - 사용자가 엔터만 누르거나 "없음"/"스킵"을 입력하면 Step 3를 종료한다.
-- 예시 입력: `dev`, `dev, code-reviewer`
+- 예시 입력: `planner`, `dev, code-reviewer`
 
 ### 3f. 선택된 에이전트별 설정
 
 선택된 각 에이전트에 대해 순차적으로:
 
-**Provider 선택:**
-```
-── {agent} ──
-Provider:
-  [1] claude
-  [2] codex
-```
+**Model 선택:**
 
-**Model 선택 (provider에 따라 목록이 다름):**
+카탈로그에서 `status: active` 모델 조합을 번호 목록으로 표시한다. 모델 설명은 표시하지 않고 provider/model/reasoning ID만 보여준다. 첫 항목은 항상 기본값이다.
 
-카탈로그에서 해당 provider의 models 배열을 번호 목록으로 표시한다. 1번이 추천.
-
-claude 선택 시:
 ```
 Model:
-  [1] Opus — 최고 품질, 복잡한 구현 (추천)
-  [2] Sonnet — 빠르고 저렴, Opus급 성능
-  [3] Haiku — 최저 비용, 단순 태스크
+  [1] default: {default provider} / {default model} {default reasoning}
+  [2] claude / opus
+  [3] claude / claude-opus-4-7
+  [4] claude / claude-opus-4-6
+  [5] claude / sonnet
+  [6] claude / claude-sonnet-4-6
+  [7] claude / haiku
+  [8] claude / claude-haiku-4-5
+  [9] codex / gpt-5.5 / xhigh
+  [10] codex / gpt-5.5 / high
+  [11] codex / gpt-5.5 / medium
+  ...
 ```
 
-codex 선택 시:
-```
-Model:
-  [1] GPT-5.4 xhigh (추천) — 최고 성능, 토큰 多
-  [2] GPT-5.4 high — 고성능, 균형잡힌 비용
-  [3] GPT-5.4 medium — 빠르고 저렴
-  [4] o3 high — 추론 특화
-  [5] o3 medium — 추론 특화, 저비용
-  [6] GPT-5.4 Mini — 최저 비용
-```
+codex가 설치되어 있지 않으면 codex 항목은 제외한다.
 
 ### 3g. 설정 저장
 
@@ -226,7 +223,7 @@ Model:
 ```json
 {
   "providers": {
-    "dev": { "provider": "codex", "model": "gpt-5.4", "reasoning": "xhigh" }
+    "planner": { "provider": "codex", "model": "gpt-5.5", "reasoning": "high" }
   }
 }
 ```
@@ -238,8 +235,8 @@ Model:
 
 ```
 ✓ Provider 설정 완료:
-  - dev: codex / gpt-5.4 xhigh
-  - code-reviewer: claude / opus (기본값)
+  - planner: codex / gpt-5.5 high
+  - dev: codex / gpt-5.5 medium (기본값)
   - qa: claude / sonnet (기본값)
 
 설정 파일: ~/.claude/crew/config.json (유저 레벨 — 모든 프로젝트 공유)

--- a/skills/crew-setup/SKILL.md
+++ b/skills/crew-setup/SKILL.md
@@ -141,6 +141,12 @@ git rev-parse --show-toplevel
 
 `data/provider-catalog.json`을 읽어 사용 가능한 provider와 model 목록을 로드한다.
 
+카탈로그의 역할:
+- `claude.models`: 선택 가능한 Claude 모델 ID
+- `codex.models`: 선택 가능한 Codex 모델/reasoning 조합
+- `agent_defaults`: 에이전트별 기본 provider/model
+- `agent_runtime`: 에이전트별 Codex sandbox 정책 (`dev`만 `workspace-write`, 나머지는 `read-only`)
+
 ### 3c. Codex CLI 가용성 확인
 
 ```bash
@@ -230,6 +236,7 @@ codex가 설치되어 있지 않으면 codex 항목은 제외한다.
 
 - claude provider일 때: `reasoning` 필드 생략
 - codex provider일 때: 카탈로그의 `reasoning` 값 포함 (`null`이면 생략)
+- `agent_runtime`은 유저 config에 저장하지 않는다. runtime 권한은 플러그인 카탈로그 정책을 따른다.
 
 ### 3h. 확인 메시지
 


### PR DESCRIPTION
## Summary
- embed a vendored Codex app-server companion runtime under scripts/crew-codex
- update provider catalog to support Claude version IDs and default dev/code-reviewer to codex gpt-5.5 medium
- update setup/dev/plan/interview docs for per-agent provider model resolution and embedded Codex execution
- add Apache-2.0 third-party notices for vendored Codex runtime

## Verification
- node --check scripts/crew-codex-companion.mjs
- node --check scripts/crew-codex/app-server-broker.mjs
- node --check scripts/crew-codex/lib/*.mjs
- JSON parse data/provider-catalog.json
- npm pack --dry-run

## Notes
- A real Codex task run was not completed in the sandbox because Codex could not access ~/.codex/sessions due to local permission restrictions.