### PR TITLE
fix: crew-plan/crew-interview 스킬에 Provider 설정 로드 단계 추가

### DIFF
--- a/skills/crew-interview/SKILL.md
+++ b/skills/crew-interview/SKILL.md
@@ -34,11 +34,42 @@ description: 유저 요구사항을 인터뷰하여 개발 가능한 수준의 s
 
 ## 실행 순서
 
-PM 판단/질문/spec 작성 단계도 provider 설정 대상이다. 오케스트레이터는 `pm` 설정을 해석한 뒤 아래 인터뷰 로직을 PM 작업 프롬프트로 구성하여 `runAgent(role="pm", ...)`로 실행한다.
+PM 판단/질문/spec 작성 단계, Explorer 호출, Researcher 호출은 모두 provider 설정 대상이다. 오케스트레이터는 **반드시 Phase 0에서 provider 설정을 먼저 해석한 뒤**, 각 단계의 디스패치를 분기한다. 본 문서의 `runAgent(role, ...)` 표기는 모두 의사코드이며, 실제로는 Phase 0의 해석 테이블과 메타 섹션의 분기 규칙대로 `Agent` 또는 `Bash(crew-codex-companion)`를 직접 호출한다.
 
-- PM이 Claude provider이면 기존처럼 `AskUserQuestion`, Read/Write를 사용할 수 있다.
-- PM이 Codex provider이면 직접 질문하거나 `.crew/` 파일을 쓰지 않는다. 질문이 필요하면 `blocked_on_user`, 추가 탐색이 필요하면 `needs_agent`, 최종 spec은 `complete.artifact`로 반환한다.
+- PM이 Claude provider이면 오케스트레이터가 인터뷰 로직을 직접 수행하면서 `AskUserQuestion`, Read/Write를 사용한다.
+- PM이 Codex provider이면 인터뷰 로직 자체를 codex companion task로 위임한다. Codex는 직접 질문하거나 `.crew/` 파일을 쓰지 않는다. 질문이 필요하면 `blocked_on_user`, 추가 탐색이 필요하면 `needs_agent`, 최종 spec은 `complete.artifact`로 반환한다.
 - Codex PM의 `artifact`는 오케스트레이터가 `.crew/plans/{task-id}/spec.md`로 저장한다.
+
+### Phase 0 — Provider 설정 로드 (오케스트레이터 직접, 필수 선행 단계)
+
+이 Phase를 건너뛰지 않는다. 어떤 단계든 에이전트 호출 직전에 Phase 0의 해석 테이블이 출력되어 있어야 한다.
+
+**0a. cascading 해석**:
+
+1. `${CLAUDE_PLUGIN_ROOT}/data/provider-catalog.json`을 읽어 `agent_defaults`와 `agent_runtime`을 로드한다.
+2. `~/.claude/crew/config.json`이 있으면 `providers.{role}` 필드로 user-level 오버라이드를 적용한다.
+3. `{projectRoot}/.crew/config.json`이 있으면 `providers.{role}` 필드로 project-level 오버라이드를 다시 적용한다 (최우선).
+4. 본 스킬의 적용 대상 role은 `pm`, `explorer`, `researcher` 세 개다. 각 role의 `{provider, model, reasoning?, codex_sandbox}` 값을 결정한다.
+
+**0b. Codex 가용성 확인**:
+
+해석 결과 중 codex provider가 하나라도 있으면 `which codex`(또는 `bash -lc 'command -v codex'`)로 가용성을 확인한다.
+- codex가 없으면 해당 role을 catalog default(claude/{model})로 폴백하고 경고를 출력한다.
+
+**0c. 해석 테이블 출력 (필수)**:
+
+해석 결과를 다음 형식으로 stdout에 인쇄한다. 이 테이블이 출력되지 않은 채 Phase 1 이후로 진행하지 않는다.
+
+```
+provider 해석:
+- pm: {provider} / {model}{reasoning이 있으면 / {reasoning}} ({codex_sandbox})
+- explorer: {provider} / {model}{...}
+- researcher: {provider} / {model}{...}
+```
+
+이후 Phase 1/2/3/4의 디스패치는 이 테이블의 값을 기준으로 한다. PM provider가 codex이면 인터뷰 로직 전체를 codex companion task로 한 번에 위임하고, claude이면 오케스트레이터가 직접 수행한다.
+
+---
 
 ### Phase 1 — 초기화 (자동)
 
@@ -305,7 +336,7 @@ spec.md를 작성했습니다. 검토해주세요.
 
 ## 에이전트 호출 규칙
 
-오케스트레이터는 모든 에이전트를 `runAgent(role, prompt, providerConfig)` 규칙으로 호출한다.
+본 메타 규칙은 Phase 0의 해석 결과를 기준으로 적용한다. 본 문서의 `runAgent(role, prompt, providerConfig)` 표기는 의사코드이며, 실제 호출은 항상 Phase 0의 해석 테이블에서 해당 role의 provider를 확인한 뒤 아래 분기 규칙에 따라 `Agent` 또는 `Bash`로 직접 디스패치한다.
 
 - Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
 - Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`

--- a/skills/crew-interview/SKILL.md
+++ b/skills/crew-interview/SKILL.md
@@ -34,31 +34,28 @@ description: 유저 요구사항을 인터뷰하여 개발 가능한 수준의 s
 
 ## 실행 순서
 
-PM 판단/질문/spec 작성 단계, Explorer 호출, Researcher 호출은 모두 provider 설정 대상이다. 오케스트레이터는 **반드시 Phase 0에서 provider 설정을 먼저 해석한 뒤**, 각 단계의 디스패치를 분기한다. 본 문서의 `runAgent(role, ...)` 표기는 모두 의사코드이며, 실제로는 Phase 0의 해석 테이블과 메타 섹션의 분기 규칙대로 `Agent` 또는 `Bash(crew-codex-companion)`를 직접 호출한다.
+PM 판단/질문/spec 작성 단계, Explorer 호출, Researcher 호출은 모두 provider 설정 대상이다. 오케스트레이터는 **반드시 Phase 1a에서 provider 설정을 먼저 해석한 뒤**, 각 단계의 디스패치를 분기한다. 본 문서의 `runAgent(role, ...)` 표기는 모두 의사코드이며, 실제로는 Phase 1a의 해석 테이블과 메타 섹션의 분기 규칙대로 `Agent` 또는 `Bash(crew-codex-companion)`를 직접 호출한다.
 
 - PM이 Claude provider이면 오케스트레이터가 인터뷰 로직을 직접 수행하면서 `AskUserQuestion`, Read/Write를 사용한다.
 - PM이 Codex provider이면 인터뷰 로직 자체를 codex companion task로 위임한다. Codex는 직접 질문하거나 `.crew/` 파일을 쓰지 않는다. 질문이 필요하면 `blocked_on_user`, 추가 탐색이 필요하면 `needs_agent`, 최종 spec은 `complete.artifact`로 반환한다.
 - Codex PM의 `artifact`는 오케스트레이터가 `.crew/plans/{task-id}/spec.md`로 저장한다.
 
-### Phase 0 — Provider 설정 로드 (오케스트레이터 직접, 필수 선행 단계)
+### Phase 1 — 초기화 (자동)
 
-이 Phase를 건너뛰지 않는다. 어떤 단계든 에이전트 호출 직전에 Phase 0의 해석 테이블이 출력되어 있어야 한다.
+**1a. Provider 설정 로드**
 
-**0a. cascading 해석**:
+이 단계를 건너뛰지 않는다. 어떤 단계든 에이전트 호출 직전에 1a의 해석 테이블이 출력되어 있어야 한다.
+
+cascading 해석:
 
 1. `${CLAUDE_PLUGIN_ROOT}/data/provider-catalog.json`을 읽어 `agent_defaults`와 `agent_runtime`을 로드한다.
 2. `~/.claude/crew/config.json`이 있으면 `providers.{role}` 필드로 user-level 오버라이드를 적용한다.
 3. `{projectRoot}/.crew/config.json`이 있으면 `providers.{role}` 필드로 project-level 오버라이드를 다시 적용한다 (최우선).
 4. 본 스킬의 적용 대상 role은 `pm`, `explorer`, `researcher` 세 개다. 각 role의 `{provider, model, reasoning?, codex_sandbox}` 값을 결정한다.
 
-**0b. Codex 가용성 확인**:
+Codex 가용성 확인: 해석 결과 중 codex provider가 하나라도 있으면 `which codex`(또는 `bash -lc 'command -v codex'`)로 가용성을 확인한다. codex가 없으면 해당 role을 catalog default(claude/{model})로 폴백하고 경고를 출력한다.
 
-해석 결과 중 codex provider가 하나라도 있으면 `which codex`(또는 `bash -lc 'command -v codex'`)로 가용성을 확인한다.
-- codex가 없으면 해당 role을 catalog default(claude/{model})로 폴백하고 경고를 출력한다.
-
-**0c. 해석 테이블 출력 (필수)**:
-
-해석 결과를 다음 형식으로 stdout에 인쇄한다. 이 테이블이 출력되지 않은 채 Phase 1 이후로 진행하지 않는다.
+해석 테이블 출력 (필수): 해석 결과를 다음 형식으로 stdout에 인쇄한다. 이 테이블이 출력되지 않은 채 1b 이후로 진행하지 않는다.
 
 ```
 provider 해석:
@@ -69,16 +66,12 @@ provider 해석:
 
 이후 Phase 1/2/3/4의 디스패치는 이 테이블의 값을 기준으로 한다. PM provider가 codex이면 인터뷰 로직 전체를 codex companion task로 한 번에 위임하고, claude이면 오케스트레이터가 직접 수행한다.
 
----
-
-### Phase 1 — 초기화 (자동)
-
-**1a. task-id 생성 + brief.md 작성**
+**1b. task-id 생성 + brief.md 작성**
 
 유저 요청 원문을 `.crew/plans/{task-id}/brief.md`에 저장한다.
 task-id는 요청 내용에서 키워드를 추출하여 kebab-case로 생성한다.
 
-**1b. Explorer 호출 (병렬)**
+**1c. Explorer 호출 (병렬)**
 
 Explorer 서브에이전트를 병렬로 호출하여 프로젝트 구조를 파악한다.
 
@@ -93,7 +86,7 @@ runAgent(role="explorer", description="프로젝트 구조 탐색", prompt="..."
 
 탐색 결과는 오케스트레이터가 내부적으로 보유한다. 파일로 저장하지 않는다.
 
-**1c. 체크리스트 첫 평가**
+**1d. 체크리스트 첫 평가**
 
 유저 요청 + Explorer 결과를 기반으로 체크리스트 5개 항목을 첫 평가한다.
 
@@ -336,7 +329,7 @@ spec.md를 작성했습니다. 검토해주세요.
 
 ## 에이전트 호출 규칙
 
-본 메타 규칙은 Phase 0의 해석 결과를 기준으로 적용한다. 본 문서의 `runAgent(role, prompt, providerConfig)` 표기는 의사코드이며, 실제 호출은 항상 Phase 0의 해석 테이블에서 해당 role의 provider를 확인한 뒤 아래 분기 규칙에 따라 `Agent` 또는 `Bash`로 직접 디스패치한다.
+본 메타 규칙은 Phase 1a의 해석 결과를 기준으로 적용한다. 본 문서의 `runAgent(role, prompt, providerConfig)` 표기는 의사코드이며, 실제 호출은 항상 Phase 1a의 해석 테이블에서 해당 role의 provider를 확인한 뒤 아래 분기 규칙에 따라 `Agent` 또는 `Bash`로 직접 디스패치한다.
 
 - Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
 - Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`
@@ -345,7 +338,7 @@ spec.md를 작성했습니다. 검토해주세요.
 
 | 에이전트 | subagent_type | 기본 provider/model | 용도 | 호출 시점 |
 |----------|--------------|------|------|----------|
-| Explorer | explorer | `agent_defaults.explorer` | 코드베이스 탐색 (read-only) | Phase 1b (필수), Phase 2d (필요 시) |
+| Explorer | explorer | `agent_defaults.explorer` | 코드베이스 탐색 (read-only) | Phase 1c (필수), Phase 2d (필요 시) |
 | Researcher | researcher | `agent_defaults.researcher` | 외부 조사 (WebSearch) | Phase 2 중 필요 시 |
 
 **중요**: provider/model은 `.crew/config.json`, `~/.claude/crew/config.json`, `data/provider-catalog.json`의 `agent_defaults` 순서로 해석한다.

--- a/skills/crew-plan/SKILL.md
+++ b/skills/crew-plan/SKILL.md
@@ -40,31 +40,28 @@ crew-interview가 생성한 spec.md를 입력으로 받아 **HOW(어떻게 만�
 
 ## 실행 순서
 
-TechLead, Planner, PlanEvaluator, Explorer, Researcher는 모두 provider 설정 대상이다. 오케스트레이터는 **반드시 Step 0에서 provider 설정을 먼저 해석한 뒤**, 각 단계의 디스패치를 분기한다. 본 문서에 등장하는 `runAgent(role, prompt, providerConfig)` 표기는 모두 의사코드이며, 실제로는 Step 0의 해석 테이블과 각 Step의 분기 규칙대로 `Agent` 또는 `Bash(crew-codex-companion)`를 직접 호출한다.
+TechLead, Planner, PlanEvaluator, Explorer, Researcher는 모두 provider 설정 대상이다. 오케스트레이터는 **반드시 Step 1a에서 provider 설정을 먼저 해석한 뒤**, 각 단계의 디스패치를 분기한다. 본 문서에 등장하는 `runAgent(role, prompt, providerConfig)` 표기는 모두 의사코드이며, 실제로는 Step 1a의 해석 테이블과 각 Step의 분기 규칙대로 `Agent` 또는 `Bash(crew-codex-companion)`를 직접 호출한다.
 
 - Claude provider이면 기존 Claude Code `Agent` 호출을 사용한다.
 - Codex provider이면 read-only companion task를 사용하고, 산출물은 `<crew-agent-result>.artifact`로 반환받아 오케스트레이터가 `.crew/` 파일에 저장한다.
 - Codex TechLead/Planner가 Explorer/Researcher가 필요하면 직접 호출하지 않고 `needs_agent`를 반환한다. 오케스트레이터가 요청된 에이전트를 실행한 뒤 결과를 원래 Codex thread에 `--resume-last`로 주입한다.
 
-### Step 0 — Provider 설정 로드 (오케스트레이터 직접, 필수 선행 단계)
+### Step 1 — 환경 준비 (오케스트레이터 직접)
 
-이 Step을 건너뛰지 않는다. 어떤 단계든 에이전트 호출 직전에 Step 0의 해석 테이블이 출력되어 있어야 한다.
+**1a. Provider 설정 로드**
 
-**0a. cascading 해석**:
+이 단계를 건너뛰지 않는다. 어떤 단계든 에이전트 호출 직전에 1a의 해석 테이블이 출력되어 있어야 한다.
+
+cascading 해석:
 
 1. `${CLAUDE_PLUGIN_ROOT}/data/provider-catalog.json`을 읽어 `agent_defaults`와 `agent_runtime`을 로드한다.
 2. `~/.claude/crew/config.json`이 있으면 `providers.{role}` 필드로 user-level 오버라이드를 적용한다.
 3. `{projectRoot}/.crew/config.json`이 있으면 `providers.{role}` 필드로 project-level 오버라이드를 다시 적용한다 (최우선).
 4. 본 스킬의 적용 대상 role은 `techlead`, `planner`, `plan-evaluator`, `explorer`, `researcher` 다섯 개다. 각 role의 `{provider, model, reasoning?, codex_sandbox}` 값을 결정한다.
 
-**0b. Codex 가용성 확인**:
+Codex 가용성 확인: 해석 결과 중 codex provider가 하나라도 있으면 `which codex`(또는 `bash -lc 'command -v codex'`)로 가용성을 확인한다. codex가 없으면 해당 role을 catalog default(claude/{model})로 폴백하고 경고를 출력한다.
 
-해석 결과 중 codex provider가 하나라도 있으면 `which codex`(또는 `bash -lc 'command -v codex'`)로 가용성을 확인한다.
-- codex가 없으면 해당 role을 catalog default(claude/{model})로 폴백하고 경고를 출력한다.
-
-**0c. 해석 테이블 출력 (필수)**:
-
-해석 결과를 다음 형식으로 stdout에 인쇄한다. 이 테이블이 출력되지 않은 채 Step 1 이후로 진행하지 않는다.
+해석 테이블 출력 (필수): 해석 결과를 다음 형식으로 stdout에 인쇄한다. 이 테이블이 출력되지 않은 채 1b 이후로 진행하지 않는다.
 
 ```
 provider 해석:
@@ -77,9 +74,7 @@ provider 해석:
 
 이후 Step 2/3/4의 디스패치는 이 테이블의 값을 기준으로 한다.
 
----
-
-### Step 1 — spec.md 유효성 검사 (오케스트레이터 직접)
+**1b. spec.md 유효성 검사**
 
 `.crew/plans/{task-id}/spec.md`를 확인한다.
 
@@ -97,7 +92,7 @@ spec.md가 없거나 비어 있습니다. crew-interview를 먼저 실행해야 
 
 ### Step 2 — TechLead 에이전트 실행
 
-**provider/model**: Step 0의 해석 테이블에서 `techlead`의 값을 사용한다. catalog default는 `agent_defaults.techlead`(claude/opus)이지만, user/project config가 우선한다.
+**provider/model**: Step 1a의 해석 테이블에서 `techlead`의 값을 사용한다. catalog default는 `agent_defaults.techlead`(claude/opus)이지만, user/project config가 우선한다.
 
 해석 테이블의 provider 값에 따라 분기 디스패치한다:
 
@@ -199,7 +194,7 @@ TechLead의 analysis.md에서 테스트 인프라 섹션을 확인한 후, 오�
 
 ### Step 3 — Planner 에이전트 실행
 
-**provider/model**: Step 0의 해석 테이블에서 `planner`의 값을 사용한다. catalog default는 `agent_defaults.planner`(claude/opus)이지만, user/project config가 우선한다.
+**provider/model**: Step 1a의 해석 테이블에서 `planner`의 값을 사용한다. catalog default는 `agent_defaults.planner`(claude/opus)이지만, user/project config가 우선한다.
 
 해석 테이블의 provider 값에 따라 분기 디스패치한다:
 
@@ -313,7 +308,7 @@ plan.md 최상단에 "이전 피드백 반영" 섹션을 추가한다.
 
 ### Step 4 — PlanEvaluator 에이전트 실행
 
-**provider/model**: Step 0의 해석 테이블에서 `plan-evaluator`의 값을 사용한다. catalog default는 `agent_defaults.plan-evaluator`(claude/sonnet)이지만, user/project config가 우선한다.
+**provider/model**: Step 1a의 해석 테이블에서 `plan-evaluator`의 값을 사용한다. catalog default는 `agent_defaults.plan-evaluator`(claude/sonnet)이지만, user/project config가 우선한다.
 
 해석 테이블의 provider 값에 따라 분기 디스패치한다:
 
@@ -549,7 +544,7 @@ Planner + PlanEvaluator 사이클은 최대 5회 (초기 1회 + retry 최대 4�
 
 ## 에이전트 호출 컨텍스트 규칙
 
-본 메타 규칙은 Step 0의 해석 결과를 기준으로 적용한다. 본 문서의 `runAgent(role, prompt, providerConfig)` 표기는 의사코드이며, 실제 호출은 항상 Step 0의 해석 테이블에서 해당 role의 provider를 확인한 뒤 아래 분기 규칙에 따라 `Agent` 또는 `Bash`로 직접 디스패치한다.
+본 메타 규칙은 Step 1a의 해석 결과를 기준으로 적용한다. 본 문서의 `runAgent(role, prompt, providerConfig)` 표기는 의사코드이며, 실제 호출은 항상 Step 1a의 해석 테이블에서 해당 role의 provider를 확인한 뒤 아래 분기 규칙에 따라 `Agent` 또는 `Bash`로 직접 디스패치한다.
 
 - Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
 - Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`

--- a/skills/crew-plan/SKILL.md
+++ b/skills/crew-plan/SKILL.md
@@ -40,11 +40,44 @@ crew-interview가 생성한 spec.md를 입력으로 받아 **HOW(어떻게 만�
 
 ## 실행 순서
 
-TechLead, Planner, PlanEvaluator는 모두 provider 설정 대상이다. 오케스트레이터는 각 단계에서 `runAgent(role, prompt, providerConfig)`를 사용한다.
+TechLead, Planner, PlanEvaluator, Explorer, Researcher는 모두 provider 설정 대상이다. 오케스트레이터는 **반드시 Step 0에서 provider 설정을 먼저 해석한 뒤**, 각 단계의 디스패치를 분기한다. 본 문서에 등장하는 `runAgent(role, prompt, providerConfig)` 표기는 모두 의사코드이며, 실제로는 Step 0의 해석 테이블과 각 Step의 분기 규칙대로 `Agent` 또는 `Bash(crew-codex-companion)`를 직접 호출한다.
 
 - Claude provider이면 기존 Claude Code `Agent` 호출을 사용한다.
 - Codex provider이면 read-only companion task를 사용하고, 산출물은 `<crew-agent-result>.artifact`로 반환받아 오케스트레이터가 `.crew/` 파일에 저장한다.
 - Codex TechLead/Planner가 Explorer/Researcher가 필요하면 직접 호출하지 않고 `needs_agent`를 반환한다. 오케스트레이터가 요청된 에이전트를 실행한 뒤 결과를 원래 Codex thread에 `--resume-last`로 주입한다.
+
+### Step 0 — Provider 설정 로드 (오케스트레이터 직접, 필수 선행 단계)
+
+이 Step을 건너뛰지 않는다. 어떤 단계든 에이전트 호출 직전에 Step 0의 해석 테이블이 출력되어 있어야 한다.
+
+**0a. cascading 해석**:
+
+1. `${CLAUDE_PLUGIN_ROOT}/data/provider-catalog.json`을 읽어 `agent_defaults`와 `agent_runtime`을 로드한다.
+2. `~/.claude/crew/config.json`이 있으면 `providers.{role}` 필드로 user-level 오버라이드를 적용한다.
+3. `{projectRoot}/.crew/config.json`이 있으면 `providers.{role}` 필드로 project-level 오버라이드를 다시 적용한다 (최우선).
+4. 본 스킬의 적용 대상 role은 `techlead`, `planner`, `plan-evaluator`, `explorer`, `researcher` 다섯 개다. 각 role의 `{provider, model, reasoning?, codex_sandbox}` 값을 결정한다.
+
+**0b. Codex 가용성 확인**:
+
+해석 결과 중 codex provider가 하나라도 있으면 `which codex`(또는 `bash -lc 'command -v codex'`)로 가용성을 확인한다.
+- codex가 없으면 해당 role을 catalog default(claude/{model})로 폴백하고 경고를 출력한다.
+
+**0c. 해석 테이블 출력 (필수)**:
+
+해석 결과를 다음 형식으로 stdout에 인쇄한다. 이 테이블이 출력되지 않은 채 Step 1 이후로 진행하지 않는다.
+
+```
+provider 해석:
+- techlead: {provider} / {model}{reasoning이 있으면 / {reasoning}} ({codex_sandbox})
+- planner: {provider} / {model}{...}
+- plan-evaluator: {provider} / {model}{...}
+- explorer: {provider} / {model}{...}
+- researcher: {provider} / {model}{...}
+```
+
+이후 Step 2/3/4의 디스패치는 이 테이블의 값을 기준으로 한다.
+
+---
 
 ### Step 1 — spec.md 유효성 검사 (오케스트레이터 직접)
 
@@ -64,15 +97,23 @@ spec.md가 없거나 비어 있습니다. crew-interview를 먼저 실행해야 
 
 ### Step 2 — TechLead 에이전트 실행
 
-**provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.techlead`).
+**provider/model**: Step 0의 해석 테이블에서 `techlead`의 값을 사용한다. catalog default는 `agent_defaults.techlead`(claude/opus)이지만, user/project config가 우선한다.
 
-Claude provider 호출 예:
+해석 테이블의 provider 값에 따라 분기 디스패치한다:
 
-```
-Agent(subagent_type="techlead", description="TechLead: {task-id} 사전 분석", prompt="...")
-```
+- **claude**:
+  ```
+  Agent(subagent_type="techlead", model="{model}", description="TechLead: {task-id} 사전 분석", prompt="...")
+  ```
+- **codex**:
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}
+  ```
+  - `agent_runtime.techlead.codex_sandbox`가 `workspace-write`인 경우에만 `--write`를 추가한다 (plan 단계 에이전트는 모두 read-only).
+  - Codex는 `.crew/`에 직접 접근하지 않으므로, `spec.md` 내용을 `{promptFile}`에 인라인 주입한다.
+  - 마지막 `<crew-agent-result>` 블록의 `artifact`를 추출하여 Step 2 결과 저장에 사용한다.
 
-에이전트 프롬프트:
+에이전트 프롬프트 (claude/codex 공통, codex의 경우 `{promptFile}`에 그대로 주입):
 
 ```
 당신은 TechLead 에이전트다. 사전 분석을 수행하고 아키텍처 방향을 판단한다.
@@ -158,13 +199,21 @@ TechLead의 analysis.md에서 테스트 인프라 섹션을 확인한 후, 오�
 
 ### Step 3 — Planner 에이전트 실행
 
-**provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.planner`).
+**provider/model**: Step 0의 해석 테이블에서 `planner`의 값을 사용한다. catalog default는 `agent_defaults.planner`(claude/opus)이지만, user/project config가 우선한다.
 
-Claude provider 호출 예:
+해석 테이블의 provider 값에 따라 분기 디스패치한다:
 
-```
-Agent(subagent_type="planner", description="Planner: {task-id} 구현 계획", prompt="...")
-```
+- **claude**:
+  ```
+  Agent(subagent_type="planner", model="{model}", description="Planner: {task-id} 구현 계획", prompt="...")
+  ```
+- **codex**:
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}
+  ```
+  - `agent_runtime.planner.codex_sandbox`가 `workspace-write`인 경우에만 `--write` 추가 (Planner는 read-only).
+  - 첫 번째 실행 시 `spec.md` + `analysis.md`를 `{promptFile}`에 인라인 주입한다. retry 시 추가로 `review-{n}.md`를 주입한다.
+  - Planner는 plan.md 작성을 직접 수행해야 하나, codex provider는 `.crew/`에 쓰지 않으므로 `artifact`로 plan.md 본문 텍스트를 반환받아 오케스트레이터가 저장한다.
 
 **첫 번째 실행 시 에이전트 프롬프트**:
 
@@ -264,13 +313,21 @@ plan.md 최상단에 "이전 피드백 반영" 섹션을 추가한다.
 
 ### Step 4 — PlanEvaluator 에이전트 실행
 
-**provider/model**: 설정 resolver가 결정한다 (기본값: `agent_defaults.plan-evaluator`).
+**provider/model**: Step 0의 해석 테이블에서 `plan-evaluator`의 값을 사용한다. catalog default는 `agent_defaults.plan-evaluator`(claude/sonnet)이지만, user/project config가 우선한다.
 
-Claude provider 호출 예:
+해석 테이블의 provider 값에 따라 분기 디스패치한다:
 
-```
-Agent(subagent_type="plan-evaluator", description="PlanEvaluator: {task-id} 계획 검증", prompt="...")
-```
+- **claude**:
+  ```
+  Agent(subagent_type="plan-evaluator", model="{model}", description="PlanEvaluator: {task-id} 계획 검증", prompt="...")
+  ```
+- **codex**:
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}
+  ```
+  - PlanEvaluator는 read-only이므로 `--write`를 붙이지 않는다.
+  - `spec.md` + `analysis.md` + `plan.md`를 `{promptFile}`에 인라인 주입한다.
+  - 마지막 `<crew-agent-result>` 블록의 `artifact`를 추출하여 Step 4 결과 저장(`review.md`)에 사용한다.
 
 에이전트 프롬프트:
 
@@ -492,7 +549,7 @@ Planner + PlanEvaluator 사이클은 최대 5회 (초기 1회 + retry 최대 4�
 
 ## 에이전트 호출 컨텍스트 규칙
 
-오케스트레이터는 모든 에이전트를 `runAgent(role, prompt, providerConfig)` 규칙으로 호출한다.
+본 메타 규칙은 Step 0의 해석 결과를 기준으로 적용한다. 본 문서의 `runAgent(role, prompt, providerConfig)` 표기는 의사코드이며, 실제 호출은 항상 Step 0의 해석 테이블에서 해당 role의 provider를 확인한 뒤 아래 분기 규칙에 따라 `Agent` 또는 `Bash`로 직접 디스패치한다.
 
 - Claude provider: `Agent(subagent_type="{role}", model="{model}", description="...", prompt="...")`
 - Codex provider: `node "${CLAUDE_PLUGIN_ROOT}/scripts/crew-codex-companion.mjs" task --json --expect-crew-result --model {model} --effort {reasoning} --prompt-file {promptFile}`


### PR DESCRIPTION
## Summary

- crew-plan과 crew-interview가 user/project config를 무시하고 모든 에이전트를 Claude `Agent(subagent_type=...)`로만 호출하던 버그를 수정
- 두 스킬에 명시적 **Step 0 / Phase 0 — Provider 설정 로드** 단계를 추가 (crew-dev의 Phase 1a와 동일 패턴). cascading 해석 → 해석 테이블 stdout 출력 → 이후 단계 분기 강제
- 각 Step의 "Claude provider 호출 예:" 라벨을 제거하고 `claude` / `codex` 분기 디스패치 블록으로 교체. codex 분기에는 sandbox 정책, 인라인 주입할 입력 파일, `<crew-agent-result>.artifact` 처리까지 명시
- `runAgent(role, prompt, providerConfig)` 표기를 의사코드로 명시 — 도입부와 메타 섹션 양쪽에 박아 LLM이 SDK 함수로 오해하지 않도록 함

## Root cause

PreToolUse hook(`hooks/enforce-delegation.mjs`)은 `agents/*.md` frontmatter의 `model:` 필드만 자동 주입하며, provider 분기 능력은 없다. 따라서 provider routing 책임은 SKILL.md를 따르는 LLM 오케스트레이터에 있는데, crew-plan/crew-interview의 본문은 Claude `Agent(...)` 호출을 "예시"로 먼저 노출하고, cascading 정책은 마지막 메타 섹션에서만 다뤘다. 명시적 "config 먼저 읽기" 단계가 없어 LLM이 example을 default 경로로 채택했다.

crew-dev는 Phase 1a에 동일한 단계가 이미 있어 정상 동작하므로 본 PR에서는 수정하지 않는다.

## Test plan

자동화 lint/test가 없는 docs-only 변경. 수동 검증:

- [ ] 별도 테스트 프로젝트에서 `~/.claude/crew/config.json`에 `techlead`/`planner`를 codex로 지정한 뒤 `/claude-crew:crew-plan` 실행 → 시작 시점에 `provider 해석:` 테이블이 출력되고, TechLead/Planner 단계에서 `Bash("node .../crew-codex-companion.mjs ...")`가 호출되는지 확인
- [ ] PreToolUse hook의 `model 자동 주입: techlead → opus` 메시지가 더 이상 뜨지 않는지 확인 (Bash 호출은 hook matcher `Agent|Task`에 매칭되지 않음)
- [ ] user config를 비운 채 다시 실행하면 catalog default(claude/opus 등)대로 `Agent(...)` 호출이 되는지 회귀 확인
- [ ] crew-dev 동작에는 영향이 없는지 확인 (수정 대상 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)