### PR TITLE
fix(smoke): --dir 플래그 수정 및 sandbox 권한/codex 커버리지 추가

### DIFF
--- a/.crew/tasks/008.md
+++ b/.crew/tasks/008.md
@@ -1,0 +1,21 @@
+---
+id: "008"
+title: "smoke test에 fixture 기반 artifact 품질 채점 도입"
+status: queue
+order: 1
+created: 2026-04-29
+---
+
+oh-my-claudecode의 bench:prompts 방식을 참고하여 smoke test에 품질 채점 레이어 추가.
+
+## 아이디어
+
+- stage별 artifact(spec.md, plan.md, 코드 결과)에 대해 fixture의 기대 결과를 정의
+- LLM-as-judge 또는 구조적 검증으로 채점 (compositeScore, 수용기준 충족률)
+- baseline 저장/비교로 프롬프트 변경 시 regression 감지
+
+## 고려사항
+
+- multi-agent 파이프라인이라 단일 프롬프트 대비 결과 분산이 큼
+- fixture 3-5개로 제한, stage별 채점 기준은 간단하게 유지
+- 실행 비용/시간 트레이드오프

--- a/tests/smoke/lib/sandbox.mjs
+++ b/tests/smoke/lib/sandbox.mjs
@@ -64,5 +64,29 @@ export async function setupSandbox(pluginRoot) {
     });
   }
 
+  // 5. Write .crew/config.json — ensure at least one codex agent per stage
+  //    interview: pm, plan: explorer, dev: dev (already default)
+  try {
+    const crewDir = path.join(sandboxPath, ".crew");
+    await fs.mkdir(crewDir, { recursive: true });
+    await fs.writeFile(
+      path.join(crewDir, "config.json"),
+      JSON.stringify({
+        providers: {
+          pm: { provider: "codex", model: "gpt-5.5", reasoning: "medium" },
+          techlead: { provider: "codex", model: "gpt-5.5", reasoning: "medium" },
+          planner: { provider: "codex", model: "gpt-5.5", reasoning: "medium" },
+          dev: { provider: "codex", model: "gpt-5.5", reasoning: "medium" },
+        },
+      }, null, 2) + "\n",
+    );
+  } catch (err) {
+    results.push({
+      name: "codex-config",
+      status: "FAIL",
+      reason: err.message,
+    });
+  }
+
   return results;
 }

--- a/tests/smoke/lib/skills.mjs
+++ b/tests/smoke/lib/skills.mjs
@@ -100,7 +100,7 @@ function runClaude(sandboxPath, promptText, timeoutMs) {
     let settled = false;
     let timedOut = false;
 
-    const child = spawn("claude", ["-p", promptText], {
+    const child = spawn("claude", ["-p", "--dangerously-skip-permissions", promptText], {
       cwd: sandboxPath,
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env },

--- a/tests/smoke/lib/skills.mjs
+++ b/tests/smoke/lib/skills.mjs
@@ -89,7 +89,7 @@ const SKILL_DEFS = [
 ];
 
 /**
- * Run `claude -p --dir <sandboxPath>` with the given prompt text.
+ * Run `claude -p` with cwd set to sandboxPath.
  * Returns { exitCode, stdout, stderr }.
  * On timeout, kills the process and returns exitCode "TIMEOUT".
  */
@@ -100,7 +100,8 @@ function runClaude(sandboxPath, promptText, timeoutMs) {
     let settled = false;
     let timedOut = false;
 
-    const child = spawn("claude", ["-p", "--dir", sandboxPath, promptText], {
+    const child = spawn("claude", ["-p", promptText], {
+      cwd: sandboxPath,
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env },
     });


### PR DESCRIPTION
## Summary
- `claude -p --dir` → `spawn`의 `cwd` 옵션으로 교체 (CLI 2.x에서 `--dir` 제거됨)
- `--dangerously-skip-permissions` 추가로 non-interactive sandbox에서 permission denied 해결
- `.crew/config.json`으로 매 stage별 최소 1개 codex 에이전트 보장 (pm, techlead, planner, dev)

## Test plan
- [x] `npm run smoke` — 9/9 PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)