### PR TITLE
feat: 워크트리 생명주기를 interview부터 Claude 워크트리로 통일

### DIFF
--- a/skills/crew-dev/SKILL.md
+++ b/skills/crew-dev/SKILL.md
@@ -48,6 +48,7 @@ provider 선택, 런타임 선택, AgentResult 반환 형식, 후속 입력 주�
 - git commit 시 `--no-verify`를 생략하지 않는다. 호스트 프로젝트의 pre-commit hook 중복 실행을 방지하기 위함이다.
 - Dev가 자체 검증을 통과하지 못한 상태에서 검증 단계로 넘기지 않는다.
 - 에이전트가 허용된 산출물 범위를 넘어 `.crew/` 메타 파일을 탐색하거나 읽게 하지 않는다.
+- `git worktree add`를 직접 실행하지 않는다. 워크트리는 `EnterWorktree` 도구만 사용한다.
 
 ---
 
@@ -103,24 +104,24 @@ inputs:
 output:
 - 해석된 역할별 provider/model/runtime 정책
 - 유효성이 확인된 ACTIVE `contract.md`
-- 신규 또는 기존 워크트리 선택 결과
+- Claude 워크트리 `crew/{task-id}` 진입 결과
 - `contract.md` 상태 갱신
 
 role instructions:
 - **Phase 1a — provider 설정 해석**: 오케스트레이터는 provider 설정을 해석한다. 프로젝트 설정, 유저 설정, catalog 기본값 순으로 역할별 실행 정책을 결정하고 Phase 2, Phase 3에서 사용할 런타임 제약을 기록한다.
 - **Phase 1b — contract.md 검증**: `contract.md` 산출물을 읽는다. 파일 존재, `## 상태`의 ACTIVE 여부, `## 수용 기준`의 비어 있지 않음, `## 검증 시나리오` 존재를 확인한다.
-- **Phase 1c — 워크트리 결정**: `contract.md`의 `## 워크트리` 섹션을 우선 적용한다. 없으면 현재 디렉토리가 해당 task-id의 워크트리인지 확인한다. 신규 워크트리는 기준 브랜치에서 준비하고, 기존 워크트리는 reset 없이 이어간다.
+- **Phase 1c — 워크트리 진입**: 현재 세션이 이미 `crew/{task-id}` Claude 워크트리 안인지 확인한다. 워크트리 안이 아니면 `EnterWorktree(path: ".claude/worktrees/crew/{task-id}")`로 crew-interview/crew-plan이 생성한 기존 워크트리에 진입한다. 워크트리가 존재하지 않으면 `EnterWorktree(name: "crew/{task-id}")`로 새로 생성한다.
 - **Phase 1d — 상태 갱신**: `contract.md`의 `## 상태` 섹션을 `IN_PROGRESS`로 갱신한다.
 
 success gate:
 - provider 정책이 역할별로 해석되었다.
 - `contract.md`가 ACTIVE이며 필수 섹션을 가진다.
-- 이후 모든 작업이 수행될 워크트리가 결정되었다.
+- Claude 워크트리 `crew/{task-id}`에 진입했다.
 - 상태가 `IN_PROGRESS`로 갱신되었다.
 
 failure handling:
 - `contract.md` 검증 실패 시 구체적 사유와 함께 사용자에게 선택지를 제시한다.
-- 워크트리 준비 실패 시 상태를 BLOCKED로 갱신하고 작업을 중단한다.
+- Claude 워크트리 진입 실패 시 상태를 BLOCKED로 갱신하고 작업을 중단한다.
 - provider 해석 중 특정 provider를 사용할 수 없으면 runner 정책에 따라 fallback 또는 escalation을 적용한다.
 
 ### Phase 2 — US 단위 증분 루프

--- a/skills/crew-interview/SKILL.md
+++ b/skills/crew-interview/SKILL.md
@@ -19,6 +19,7 @@ description: 유저 요구사항을 인터뷰하여 개발 가능한 수준의 s
 - 체크리스트가 전부 YES가 되기 전에 spec.md를 작성하지 않는다.
 - 유저 승인 없이 crew-plan으로 전환하지 않는다.
 - 추측으로 비즈니스 결정을 채우지 않는다.
+- `git worktree add`를 직접 실행하지 않는다. 워크트리는 `EnterWorktree` 도구만 사용한다.
 
 ---
 
@@ -61,17 +62,20 @@ inputs:
 - 기존 `.crew/plans/` 상태
 
 output:
+- Claude 워크트리 `crew/{task-id}` 생성 및 진입
 - `.crew/plans/{task-id}/brief.md`
 - Explorer 프로젝트 구조 요약
 - 최초 요구사항 체크리스트 평가
 
 role instructions:
 - PM은 요청 내용에서 키워드를 추출하여 kebab-case task-id를 생성한다.
+- PM이 task-id를 반환하면 오케스트레이터가 `EnterWorktree(name: "crew/{task-id}")`를 호출하여 Claude 워크트리를 생성하고 진입한다. 이후 모든 파일 작업은 워크트리 안에서 수행된다.
 - 오케스트레이터가 유저 원본 요청을 `.crew/plans/{task-id}/brief.md`에 저장한다.
 - Explorer는 프로젝트 구조를 병렬로 파악하고, 결과를 파일로 저장하지 않고 인터뷰 컨텍스트로만 제공한다.
 - PM은 유저 요청과 Explorer 결과를 기반으로 체크리스트 5개 항목을 첫 평가한다.
 
 success gate:
+- Claude 워크트리 `crew/{task-id}`에 진입했다.
 - `brief.md`가 생성되었다.
 - Explorer 결과에 기술 스택, 주요 모듈 구조, 관련 기존 코드/기능 유무, 기존 패턴이 포함되었다.
 - 체크리스트 각 항목이 YES / NO / 해당없음 중 하나로 판정되었다.
@@ -80,12 +84,13 @@ failure handling:
 - task-id 또는 `brief.md`를 만들 수 없으면 실패 사유와 필요한 사용자 입력을 반환한다.
 - Explorer가 충분한 구조 정보를 제공하지 못하면 누락 영역을 명시하고 추가 Explorer 탐색을 요청한다.
 
-**1b. task-id 생성 + brief.md 작성**
+**1b. task-id 생성 + 워크트리 진입 + brief.md 작성**
 
-유저 요청 원문을 `.crew/plans/{task-id}/brief.md`에 저장한다.
-task-id는 요청 내용에서 키워드를 추출하여 kebab-case로 생성한다.
+1. task-id는 요청 내용에서 키워드를 추출하여 kebab-case로 생성한다.
+2. `EnterWorktree(name: "crew/{task-id}")`를 호출하여 Claude 워크트리를 생성하고 진입한다. 이미 해당 워크트리 안이면 이 단계를 건너뛴다.
+3. 유저 요청 원문을 `.crew/plans/{task-id}/brief.md`에 저장한다.
 
-**1c. Explorer 호출 (병렬)**
+**1c. Explorer 호출 (병렬, 워크트리 진입 후)**
 
 Explorer는 중앙 runner를 통해 병렬 실행되어 프로젝트 구조를 파악한다.
 
@@ -433,7 +438,7 @@ spec.md를 작성했습니다. 검토해주세요.
 | 에이전트 | role | 용도 | 실행 시점 |
 |----------|------|------|----------|
 | PM | pm | 인터뷰 판단, 질문 생성, 스코프 정리, spec.md 결정화 | Phase 1-4 |
-| Explorer | explorer | 코드베이스 탐색 | Phase 1c 필수, Phase 2d 필요 시 |
+| Explorer | explorer | 코드베이스 탐색 | Phase 1c 필수 (워크트리 진입 후), Phase 2d 필요 시 |
 | Researcher | researcher | 외부 조사 | Phase 2 중 필요 시 |
 
 모든 역할 실행, 사용자 질문 대기, 추가 에이전트 요청, 실패 처리는 중앙 `crew-agent-runner` 스킬의 상태 처리 규칙을 따른다.
@@ -447,7 +452,8 @@ spec.md를 작성했습니다. 검토해주세요.
 {
   "status": "COMPLETE",
   "task_id": "{task-id}",
-  "spec_path": ".crew/plans/{task-id}/spec.md"
+  "spec_path": ".crew/plans/{task-id}/spec.md",
+  "worktree": "crew/{task-id}"
 }
 ```
 

--- a/skills/crew-plan/SKILL.md
+++ b/skills/crew-plan/SKILL.md
@@ -18,6 +18,7 @@ crew-interview가 생성한 spec.md를 입력으로 받아 **HOW(어떻게 만�
 - PlanEvaluator가 FAIL을 냈을 때 합리화하여 통과시키지 않는다.
 - brief.md를 Planner, PlanEvaluator에게 전달하지 않는다.
 - 오케스트레이터가 요구사항을 판단하거나 보완하지 않는다.
+- `git worktree add`를 직접 실행하지 않는다. 워크트리는 `EnterWorktree` 도구만 사용한다.
 
 ---
 
@@ -54,6 +55,27 @@ crew-plan의 모든 에이전트 실행은 역할이나 step과 무관하게 아
 
 이 순서를 생략하고 직접 하위 에이전트를 호출하지 않는다.
 provider 선택, 런타임 선택, AgentResult 반환 형식, 후속 입력 주입, retry/fallback/escalate 판단은 모두 중앙 runner 계약을 따른다.
+
+### Step 0 — 워크트리 진입
+
+role: orchestrator
+
+inputs:
+- task-id
+
+role instructions:
+- 현재 세션이 이미 `crew/{task-id}` Claude 워크트리 안인지 확인한다.
+- 워크트리 안이 아니면 `.claude/worktrees/crew/{task-id}` 경로의 워크트리가 존재하는지 확인한다.
+- 존재하면 `EnterWorktree(path: ".claude/worktrees/crew/{task-id}")`로 기존 워크트리에 진입한다.
+- 존재하지 않으면 `EnterWorktree(name: "crew/{task-id}")`로 새로 생성한다.
+
+success gate:
+- 세션이 `crew/{task-id}` Claude 워크트리 안에서 동작 중이다.
+
+failure handling:
+- 워크트리 진입 실패 시 사유를 사용자에게 제시한다.
+
+---
 
 ### Step 1 — spec.md 검증
 
@@ -247,7 +269,7 @@ output:
 
 role instructions:
 - review.md의 판정이 PASS인지 확인한다.
-- contract.md에는 목표, 수용 기준, 유저 플로우, UI 구조 및 주요 콘텐츠, 비즈니스 규칙, 가드레일, 테스트 전략, 검증 시나리오, 실행 검증, 참조 문서, 검증 이력, 워크트리, 상태를 포함한다.
+- contract.md에는 목표, 수용 기준, 유저 플로우, UI 구조 및 주요 콘텐츠, 비즈니스 규칙, 가드레일, 테스트 전략, 검증 시나리오, 실행 검증, 참조 문서, 검증 이력, 상태를 포함한다. 워크트리는 Claude 워크트리 컨벤션(`crew/{task-id}`)으로 관리되므로 contract.md에 포함하지 않는다.
 - 목표와 수용 기준은 spec.md의 내용을 기준으로 한다.
 - 가드레일은 analysis.md의 Must/Must NOT을 기준으로 한다.
 - 검증 시나리오와 실행 검증은 plan.md의 해당 섹션을 기준으로 한다.


### PR DESCRIPTION
## Summary
- interview → plan → dev 전 단계에서 Claude의 `EnterWorktree`/`ExitWorktree`만 사용하도록 통일
- `git worktree add` 직접 사용을 절대 금지 항목으로 추가 (3개 스킬 모두)
- crew-interview Phase 1에서 task-id 생성 직후 `EnterWorktree(name: "crew/{task-id}")`로 워크트리 생성 → 이후 모든 작업이 워크트리 안에서 수행
- crew-plan에 Step 0 (워크트리 진입) 신설, contract.md에서 워크트리 섹션 제거
- crew-dev Phase 1c를 Claude 워크트리 진입으로 교체

## Test plan
- [ ] `/crew-interview` 실행 시 task-id 생성 후 워크트리가 `.claude/worktrees/crew/{task-id}`에 생성되는지 확인
- [ ] interview 완료 후 새 세션에서 `/crew-plan`이 기존 워크트리에 진입하는지 확인
- [ ] `/crew-dev`가 기존 워크트리를 재사용하는지 확인
- [ ] main 브랜치에 `.crew/plans/` 파일이 남지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)