### PR TITLE
feat(catalog): codex 신규 모델 추가 및 crew-setup 권장 설정 옵션

### DIFF
--- a/data/provider-catalog.json
+++ b/data/provider-catalog.json
@@ -20,16 +20,18 @@
       { "id": "gpt-5.4", "reasoning": "medium", "status": "active" },
       { "id": "o3", "reasoning": "high", "status": "active" },
       { "id": "o3", "reasoning": "medium", "status": "active" },
-      { "id": "gpt-5.5-mini", "reasoning": "medium", "status": "active" }
+      { "id": "gpt-5.5-mini", "reasoning": "medium", "status": "active" },
+      { "id": "gpt-5.3-codex-spark", "reasoning": "low", "status": "active" },
+      { "id": "gpt-5.4-mini", "reasoning": "high", "status": "active" }
     ]
   },
   "agent_defaults": {
-    "pm": { "provider": "claude", "model": "opus" },
-    "techlead": { "provider": "claude", "model": "opus" },
-    "planner": { "provider": "claude", "model": "opus" },
+    "pm": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" },
+    "techlead": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" },
+    "planner": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" },
     "plan-evaluator": { "provider": "claude", "model": "sonnet" },
-    "explorer": { "provider": "claude", "model": "haiku" },
-    "researcher": { "provider": "claude", "model": "sonnet" },
+    "explorer": { "provider": "codex", "model": "gpt-5.3-codex-spark", "reasoning": "low" },
+    "researcher": { "provider": "codex", "model": "gpt-5.4-mini", "reasoning": "high" },
     "qa": { "provider": "claude", "model": "sonnet" },
     "dev": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" },
     "code-reviewer": { "provider": "codex", "model": "gpt-5.5", "reasoning": "medium" }

--- a/skills/crew-setup/SKILL.md
+++ b/skills/crew-setup/SKILL.md
@@ -192,11 +192,33 @@ Step 3a에서 판별된 config 경로의 파일이 있으면 현재 설정을 �
 
 ```
 설정을 변경할 에이전트를 선택하세요 (쉼표 구분, 엔터 = 스킵):
+  0. 권장 설정 전체 적용 (agent_defaults 기준)
   <data/agent-contracts.json의 role 목록을 contract 순서로 쉼표 구분 표시>
 ```
 
 - 사용자가 엔터만 누르거나 "없음"/"스킵"을 입력하면 Step 3를 종료한다.
 - 예시 입력: `planner`, `dev, code-reviewer`
+- `0` 또는 `권장` 입력 시 → Step 3f-1으로 이동한다.
+
+### 3f-1. 권장 설정 일괄 적용
+
+`provider-catalog.json`의 `agent_defaults`를 전 에이전트에 일괄 적용한다.
+
+**기존 커스텀 설정이 있는 경우 경고:**
+
+```
+⚠️  기존 커스텀 설정이 있습니다:
+  - planner: codex / gpt-5.4 high → codex / gpt-5.5 medium (덮어씀)
+  ...
+권장 설정으로 덮어씌우시겠습니까? (y/N):
+```
+
+- `y` 입력 시: 모든 에이전트를 `agent_defaults` 값으로 저장하고 Step 3h로 이동한다.
+- 그 외 입력 시: 취소하고 Step 3f로 돌아간다.
+
+**기존 커스텀 설정이 없는 경우:** 경고 없이 바로 적용하고 Step 3h로 이동한다.
+
+> **저장 규칙**: `agent_defaults`와 동일한 값은 저장하지 않는다 (3h 규칙 동일). 결과적으로 기존 커스텀 항목만 삭제되고 `providers` 객체는 비거나 빈 상태가 될 수 있다.
 
 ### 3g. 선택된 에이전트별 설정
 


### PR DESCRIPTION
## Summary

- `gpt-5.3-codex-spark` (reasoning: low), `gpt-5.4-mini` (reasoning: high) codex 모델 카탈로그 추가
- `pm` / `techlead` / `planner` 기본 provider를 claude opus → codex gpt-5.5 medium으로 전환
- `explorer` → gpt-5.3-codex-spark low, `researcher` → gpt-5.4-mini high로 전환
- `crew-setup` Step 3f에 권장 설정 일괄 적용 옵션 추가 (`0` / `권장` 입력 → agent_defaults 전 에이전트 일괄 적용)

## Test plan

- [ ] `data/provider-catalog.json`에 두 신규 모델이 올바른 reasoning으로 등록되어 있는지 확인
- [ ] `agent_defaults`의 pm/techlead/planner/explorer/researcher 값이 변경되어 있는지 확인
- [ ] `/crew-setup` 실행 후 Step 3f에서 `0` 입력 시 권장 설정 일괄 적용 흐름 동작 확인
- [ ] 기존 커스텀 설정이 있을 때 덮어쓰기 경고가 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)