### PR TITLE
fix(runner): read-only 에이전트 artifact를 runner가 대신 저장

### DIFF
--- a/scripts/crew-agent-runner.mjs
+++ b/scripts/crew-agent-runner.mjs
@@ -10,6 +10,10 @@ import {
 } from "./lib/config.mjs";
 import { parseArgv } from "./lib/cli.mjs";
 import {
+  persistCrewArtifact,
+  ArtifactPersistError
+} from "./lib/artifacts.mjs";
+import {
   dispatch,
   DispatchError,
   formatDispatchProviderGuardMessage
@@ -40,6 +44,10 @@ async function main(argv) {
 
   if (command === "dispatch") {
     return dispatchCommand(flags);
+  }
+
+  if (command === "persist-artifact") {
+    return persistArtifactCommand(flags);
   }
 
   if (command === "render-followup") {
@@ -224,6 +232,61 @@ function renderFollowupCommand(flags) {
   }
 }
 
+async function persistArtifactCommand(flags) {
+  if (typeof flags.role !== "string" || flags.role.length === 0) {
+    console.error("Missing required --role <name>");
+    return 1;
+  }
+
+  if (
+    typeof flags["result-file"] !== "string" ||
+    flags["result-file"].length === 0
+  ) {
+    console.error("Missing required --result-file <path>");
+    return 1;
+  }
+
+  if (
+    typeof flags["request-file"] !== "string" ||
+    flags["request-file"].length === 0
+  ) {
+    console.error("Missing required --request-file <path>");
+    return 1;
+  }
+
+  try {
+    const contracts = loadContracts();
+    const contract = findContract(flags.role, contracts);
+    if (!contract) {
+      throw new Error(`Unknown role: ${flags.role}`);
+    }
+
+    const agentResult = JSON.parse(readFileSync(flags["result-file"], "utf8"));
+    const request = JSON.parse(readFileSync(flags["request-file"], "utf8"));
+
+    const savedPath = await persistCrewArtifact({
+      workspaceRoot: process.cwd(),
+      contract,
+      request,
+      agentResult
+    });
+
+    if (savedPath) {
+      process.stdout.write(`${JSON.stringify({ artifact_path: savedPath })}\n`);
+    } else {
+      process.stdout.write(`${JSON.stringify({ artifact_path: null })}\n`);
+    }
+    return 0;
+  } catch (error) {
+    if (error instanceof ArtifactPersistError) {
+      console.error(error.message);
+      return 1;
+    }
+    console.error(error.message);
+    return 1;
+  }
+}
+
 async function dispatchCommand(flags) {
   if (typeof flags.role !== "string" || flags.role.length === 0) {
     console.error("Missing required --role <name>");
@@ -375,6 +438,9 @@ function usage() {
   );
   console.error(
     "       crew-agent-runner dispatch --role <name> --request-file <path> [--json] [--resume-handle <thread-id>]"
+  );
+  console.error(
+    "       crew-agent-runner persist-artifact --role <name> --result-file <path> --request-file <path>"
   );
 }
 

--- a/scripts/lib/artifacts.mjs
+++ b/scripts/lib/artifacts.mjs
@@ -1,0 +1,89 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, normalize, resolve, relative } from "node:path";
+
+export class ArtifactPersistError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ArtifactPersistError";
+  }
+}
+
+export async function persistCrewArtifact({ workspaceRoot, contract, request, agentResult }) {
+  if (!shouldPersist(contract, agentResult)) {
+    return null;
+  }
+
+  const target = findArtifactTarget(contract);
+  if (!target) {
+    return null;
+  }
+
+  const resolvedTarget = replaceTaskId(target, request?.taskId);
+  const absolutePath = validateTargetPath(workspaceRoot, resolvedTarget);
+
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, agentResult.artifact, "utf8");
+
+  return absolutePath;
+}
+
+function shouldPersist(contract, agentResult) {
+  if (contract?.capabilities?.workspaceAccess !== "read-only") {
+    return false;
+  }
+
+  if (agentResult?.status !== "complete") {
+    return false;
+  }
+
+  if (typeof agentResult.artifact !== "string" || agentResult.artifact.length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+function findArtifactTarget(contract) {
+  const outputs = Array.isArray(contract?.outputs) ? contract.outputs : [];
+  for (const output of outputs) {
+    if (
+      output?.type === "artifact" &&
+      typeof output.target === "string" &&
+      output.target.startsWith(".crew/")
+    ) {
+      return output.target;
+    }
+  }
+  return null;
+}
+
+function replaceTaskId(target, taskId) {
+  if (typeof taskId === "string" && taskId.length > 0) {
+    return target.replace(/\{task-id\}/g, taskId);
+  }
+  return target;
+}
+
+function validateTargetPath(workspaceRoot, target) {
+  if (!workspaceRoot || typeof workspaceRoot !== "string") {
+    throw new ArtifactPersistError("workspaceRoot is required.");
+  }
+
+  const normalized = normalize(target);
+
+  if (normalized.startsWith("/") || normalized.startsWith("\\")) {
+    throw new ArtifactPersistError(`Absolute path rejected: ${target}`);
+  }
+
+  const crewBase = resolve(workspaceRoot, ".crew");
+  const absolutePath = resolve(workspaceRoot, normalized);
+  const rel = relative(crewBase, absolutePath);
+
+  if (rel.startsWith("..") || rel === "") {
+    throw new ArtifactPersistError(
+      `Target path escapes .crew/ directory: ${target}`
+    );
+  }
+
+  return absolutePath;
+}

--- a/scripts/lib/dispatch.mjs
+++ b/scripts/lib/dispatch.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { persistCrewArtifact, ArtifactPersistError } from "./artifacts.mjs";
 import { renderPrompt } from "./render.mjs";
 
 const DEFAULT_COMPANION = fileURLToPath(
@@ -82,6 +83,11 @@ export async function dispatch(input) {
         agentResult,
         companionPayload: payload
       });
+    }
+
+    const artifactPath = await persistArtifactSafe(input, agentResult);
+    if (artifactPath) {
+      return { ...agentResult, artifact_path: artifactPath };
     }
 
     return agentResult;
@@ -233,6 +239,24 @@ function resolveCompanion(input = {}) {
     command: binary,
     prefixArgs: []
   };
+}
+
+async function persistArtifactSafe(input, agentResult) {
+  try {
+    return await persistCrewArtifact({
+      workspaceRoot: process.cwd(),
+      contract: input.contract,
+      request: input.request,
+      agentResult
+    });
+  } catch (error) {
+    if (error instanceof ArtifactPersistError) {
+      throw new DispatchError(`Artifact persist failed: ${error.message}`, {
+        agentResult
+      });
+    }
+    throw error;
+  }
 }
 
 function isNodeScript(value) {

--- a/scripts/lib/render.mjs
+++ b/scripts/lib/render.mjs
@@ -8,7 +8,7 @@ export function renderPrompt(input) {
     section("Instructions", request.instruction, { required: true }),
     section("Success Gate", request.successGate),
     section("Failure Handling", request.failureHandling),
-    section("AgentResult Contract", renderAgentResultContract())
+    section("AgentResult Contract", renderAgentResultContract(contract))
   ].filter(Boolean);
 
   return `${parts.join("\n\n")}\n`;
@@ -41,7 +41,7 @@ function renderCapability(contract) {
     `canAskUser: ${String(tools.includes("AskUserQuestion"))}`,
     `canRequestAgent: ${String(tools.includes("Agent"))}`,
     `canUseShell: ${String(tools.includes("Bash"))}`,
-    `canWriteCrewFiles: ${String(canWriteCrewFiles(outputs))}`
+    `canReturnCrewArtifact: ${String(canReturnCrewArtifact(outputs, contract.capabilities?.workspaceAccess))}`
   ].join("\n");
 }
 
@@ -73,15 +73,19 @@ function renderJson(value) {
   return JSON.stringify(value, null, 2);
 }
 
-function renderAgentResultContract() {
-  return [
+function renderAgentResultContract(contract = {}) {
+  const outputs = Array.isArray(contract.outputs) ? contract.outputs : [];
+  const workspaceAccess = contract.capabilities?.workspaceAccess;
+  const returnArtifact = canReturnCrewArtifact(outputs, workspaceAccess);
+
+  const lines = [
     "Return exactly one final AgentResult JSON object wrapped in these tags:",
     "",
     "```text",
     "<crew-agent-result>",
     "{",
     '  "status": "complete | blocked_on_user | needs_agent | needs_tool | failed",',
-    '  "artifact": null,',
+    `  "artifact": ${returnArtifact ? '"full Markdown content of the artifact"' : "null"},`,
     '  "questions": [],',
     '  "requests": [],',
     '  "summary": "short summary",',
@@ -97,7 +101,15 @@ function renderAgentResultContract() {
     "- Use blocked_on_user only with a non-empty questions array.",
     "- Use needs_agent or needs_tool only with a non-empty requests array.",
     "- Use failed with an error string when the task cannot continue."
-  ].join("\n");
+  ];
+
+  if (returnArtifact) {
+    lines.push(
+      "- Do NOT write the artifact file yourself. Instead, put the full Markdown content into the artifact field as a string. The runner will validate and save it to the target path."
+    );
+  }
+
+  return lines.join("\n");
 }
 
 function normalizeBody(body) {
@@ -127,7 +139,11 @@ function titleCase(value) {
     .join("-");
 }
 
-function canWriteCrewFiles(outputs) {
+export function canReturnCrewArtifact(outputs, workspaceAccess) {
+  if (workspaceAccess !== "read-only") {
+    return false;
+  }
+
   return outputs.some((output) => {
     return (
       output?.type === "artifact" &&

--- a/tests/__snapshots__/render.test.mjs.snap
+++ b/tests/__snapshots__/render.test.mjs.snap
@@ -8,7 +8,7 @@ workspaceAccess: read-only
 canAskUser: false
 canRequestAgent: true
 canUseShell: false
-canWriteCrewFiles: true
+canReturnCrewArtifact: true
 
 ## Inputs
 ### .crew/plans/task-123/spec.md
@@ -41,7 +41,7 @@ Return exactly one final AgentResult JSON object wrapped in these tags:
 <crew-agent-result>
 {
   "status": "complete | blocked_on_user | needs_agent | needs_tool | failed",
-  "artifact": null,
+  "artifact": "full Markdown content of the artifact",
   "questions": [],
   "requests": [],
   "summary": "short summary",
@@ -57,5 +57,6 @@ Rules:
 - Use blocked_on_user only with a non-empty questions array.
 - Use needs_agent or needs_tool only with a non-empty requests array.
 - Use failed with an error string when the task cannot continue.
+- Do NOT write the artifact file yourself. Instead, put the full Markdown content into the artifact field as a string. The runner will validate and save it to the target path.
 "
 `;

--- a/tests/_helpers/fakeCompanion.mjs
+++ b/tests/_helpers/fakeCompanion.mjs
@@ -85,6 +85,21 @@ if (args[0] === "task-resume-candidate") {
       },
       1
     );
+  } else if (response === "completeArtifactString") {
+    output({
+      status: 0,
+      threadId: "thread-complete-123",
+      rawOutput: "complete",
+      crewAgentResult: {
+        status: "complete",
+        artifact: "# Analysis\nThis is the artifact content.",
+        questions: [],
+        requests: [],
+        summary: "Fake companion completed with artifact string",
+        error: null
+      },
+      crewAgentResultError: null
+    });
   } else {
     output({
       status: 0,

--- a/tests/runner/artifacts.test.mjs
+++ b/tests/runner/artifacts.test.mjs
@@ -1,0 +1,228 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { cleanupTmpDir, mkTmpDir } from "../_helpers/fs.mjs";
+import {
+  persistCrewArtifact,
+  ArtifactPersistError
+} from "../../scripts/lib/artifacts.mjs";
+
+let tmpDir;
+
+afterEach(async () => {
+  if (tmpDir) {
+    await cleanupTmpDir(tmpDir);
+    tmpDir = undefined;
+  }
+});
+
+function readOnlyContract(target = ".crew/plans/{task-id}/analysis.md") {
+  return {
+    role: "techlead",
+    outputs: [{ type: "artifact", target }],
+    capabilities: { workspaceAccess: "read-only" }
+  };
+}
+
+function writeContract() {
+  return {
+    role: "dev",
+    outputs: [
+      { type: "artifact", target: ".crew/plans/{task-id}/dev-log.md" },
+      { type: "code", target: "<workspace files>" }
+    ],
+    capabilities: { workspaceAccess: "workspace-write" }
+  };
+}
+
+function completeResult(artifact = "# Analysis\nContent here.") {
+  return {
+    status: "complete",
+    artifact,
+    questions: [],
+    requests: [],
+    summary: "done",
+    error: null
+  };
+}
+
+describe("persistCrewArtifact", () => {
+  test("saves artifact for read-only role with .crew/ target and complete status", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: readOnlyContract(),
+      request: { taskId: "task-42" },
+      agentResult: completeResult()
+    });
+
+    expect(result).toBe(join(tmpDir, ".crew/plans/task-42/analysis.md"));
+    const content = await readFile(result, "utf8");
+    expect(content).toBe("# Analysis\nContent here.");
+  });
+
+  test("replaces {task-id} in target path", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: readOnlyContract(".crew/plans/{task-id}/review.md"),
+      request: { taskId: "plan-evaluator-99" },
+      agentResult: completeResult("# Review\nPASS")
+    });
+
+    expect(result).toBe(join(tmpDir, ".crew/plans/plan-evaluator-99/review.md"));
+    const content = await readFile(result, "utf8");
+    expect(content).toBe("# Review\nPASS");
+  });
+
+  test("returns null for workspace-write role (no-op)", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: writeContract(),
+      request: { taskId: "task-42" },
+      agentResult: completeResult()
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for dev role even with artifact string", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: writeContract(),
+      request: { taskId: "task-42" },
+      agentResult: completeResult("# Dev log content")
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when status is not complete", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: readOnlyContract(),
+      request: { taskId: "task-42" },
+      agentResult: { ...completeResult(), status: "failed" }
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when artifact is null", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: readOnlyContract(),
+      request: { taskId: "task-42" },
+      agentResult: completeResult(null)
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when artifact is empty string", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: readOnlyContract(),
+      request: { taskId: "task-42" },
+      agentResult: completeResult("")
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when no .crew/ artifact output exists", async () => {
+    tmpDir = await mkTmpDir();
+
+    const contract = {
+      role: "explorer",
+      outputs: [{ type: "report", target: "stdout" }],
+      capabilities: { workspaceAccess: "read-only" }
+    };
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract,
+      request: { taskId: "task-42" },
+      agentResult: completeResult()
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects path traversal via ../", async () => {
+    tmpDir = await mkTmpDir();
+
+    await expect(
+      persistCrewArtifact({
+        workspaceRoot: tmpDir,
+        contract: readOnlyContract(".crew/../../../etc/passwd"),
+        request: { taskId: "task-42" },
+        agentResult: completeResult("malicious")
+      })
+    ).rejects.toThrow(ArtifactPersistError);
+  });
+
+  test("absolute path target is rejected by .crew/ prefix check (returns null)", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: readOnlyContract("/etc/passwd"),
+      request: {},
+      agentResult: completeResult("malicious")
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects target that resolves outside .crew/", async () => {
+    tmpDir = await mkTmpDir();
+
+    await expect(
+      persistCrewArtifact({
+        workspaceRoot: tmpDir,
+        contract: readOnlyContract(".crew/plans/../../outside.md"),
+        request: { taskId: "task-42" },
+        agentResult: completeResult("malicious")
+      })
+    ).rejects.toThrow(ArtifactPersistError);
+  });
+
+  test("rejects when workspaceRoot is missing", async () => {
+    await expect(
+      persistCrewArtifact({
+        workspaceRoot: "",
+        contract: readOnlyContract(),
+        request: { taskId: "task-42" },
+        agentResult: completeResult()
+      })
+    ).rejects.toThrow(ArtifactPersistError);
+  });
+
+  test("handles artifact with non-string type as no-op", async () => {
+    tmpDir = await mkTmpDir();
+
+    const result = await persistCrewArtifact({
+      workspaceRoot: tmpDir,
+      contract: readOnlyContract(),
+      request: { taskId: "task-42" },
+      agentResult: completeResult({ path: ".crew/plans/task-42/analysis.md" })
+    });
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- read-only 에이전트(techlead, planner, plan-evaluator 등)가 `.crew/` artifact를 직접 쓸 수 없는 문제 해결
- 에이전트는 `AgentResult.artifact`에 Markdown 본문을 문자열로 반환하고, runner가 contract outputs 검증 후 대신 저장
- `persistCrewArtifact()` 공통 저장 함수 추가 (path traversal 차단, read-only guard, `{task-id}` 치환)
- Codex dispatch 자동 저장 연결 + Claude 경로용 `persist-artifact` CLI 명령 추가
- dev/workspace-write role은 기존 직접 쓰기 흐름 유지 (no-op)

Closes #39

## Test plan

- [x] read-only role + `.crew/` artifact + complete + artifact 문자열이면 파일이 저장됨
- [x] `{task-id}` 치환이 target path에 적용됨
- [x] workspace-write role은 artifact가 있어도 runner 자동 저장이 no-op
- [x] dev role은 artifact가 있어도 runner 자동 저장이 no-op
- [x] `status !== "complete"`이면 저장하지 않음
- [x] artifact가 null이거나 빈 문자열이면 저장하지 않음
- [x] artifact가 객체(기존 형식)이면 저장하지 않음 (no-op)
- [x] `.crew/` 밖으로 빠지는 path traversal target이 거부됨
- [x] absolute path target이 거부됨
- [x] workspaceRoot가 없으면 거부됨
- [x] 기존 render/build/validate 테스트 통과
- [x] 스냅샷 갱신 (`canWriteCrewFiles` → `canReturnCrewArtifact`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)