### PR TITLE
fix: AUTO_GIT_DIFF 플레이스홀더를 실제 git diff로 치환

### DIFF
--- a/.crew/plans/direct-20260430-152031/dev-log.md
+++ b/.crew/plans/direct-20260430-152031/dev-log.md
@@ -1,0 +1,22 @@
+# Dev Log
+
+## Task
+
+GitHub issue #44: replace `AUTO_GIT_DIFF` request input placeholders with the current git diff before Codex dispatch prompt rendering.
+
+## Changes
+
+- Added `resolveAutoGitDiffInputs`, `hasAutoGitDiffInput`, and `generateAutoGitDiff` in `scripts/lib/dispatch.mjs`.
+- Wired placeholder resolution into the shared `dispatch()` path before `renderPrompt()`, so CLI dispatch and direct library dispatch calls use the same replacement behavior.
+- `generateAutoGitDiff()` now prefers staged and unstaged diffs, and falls back to `git diff HEAD~1` when the working tree has no staged/unstaged diff.
+- Added dispatch tests for exact placeholder replacement and prompt expansion.
+- Made the dispatch CLI provider-guard test self-contained by using a temporary project config instead of relying on current catalog defaults.
+
+## Validation
+
+- `npm test -- tests/runner/dispatch.test.mjs --configLoader runner` passed: 11 tests.
+- `npm test -- --configLoader runner` ran 108 tests: 107 passed, 1 failed.
+
+## Known Residual Risk
+
+- Full suite failure is unrelated to this change: `tests/runner/prepare.test.mjs` expects `plan-evaluator` to resolve to Claude, but current `data/provider-catalog.json` defaults `plan-evaluator` to Codex.

--- a/.crew/runs/direct-20260430-152031/request.json
+++ b/.crew/runs/direct-20260430-152031/request.json
@@ -1,0 +1,26 @@
+{
+  "role": "dev",
+  "mode": "direct",
+  "taskId": "direct-20260430-152031",
+  "inputs": [
+    {
+      "path": ".crew/runs/direct-20260430-152031/request.md",
+      "content": "# GitHub 이슈 #44 수정: AUTO_GIT_DIFF 플레이스홀더 치환 로직 구현\n\n## 문제\n\ncrew-dev Phase 2에서 CodeReviewer를 codex dispatch로 실행할 때, request 파일의 `content` 필드에 `\"AUTO_GIT_DIFF\"` 값을 설정하면 이 값이 실제 git diff로 치환되지 않고 리터럴 문자열 그대로 codex 에이전트에게 전달된다.\n\n## 기대 동작\n\nrequest 파일의 content에 `\"AUTO_GIT_DIFF\"`를 넣으면, runner가 현재 git diff를 생성하여 해당 값을 실제 diff 내용으로 치환한 후 codex 에이전트에게 전달해야 한다.\n\n## 수정 대상\n\n- `scripts/crew-agent-runner.mjs` — dispatch 경로에서 AUTO_GIT_DIFF 플레이스홀더 감지 및 치환 로직 추가\n- codex provider 경로 포함 모든 dispatch 경로에서 동작해야 함\n\n## 참고\n\n- request-file의 `inputs[].content` 필드에서 `\"AUTO_GIT_DIFF\"` 값을 감지\n- `git diff HEAD~1` 또는 staged/unstaged diff를 생성하여 치환\n- 치환은 runner의 prepare 또는 dispatch 단계에서 수행"
+    },
+    {
+      "path": "request.mode",
+      "content": "direct"
+    },
+    {
+      "path": "request.task",
+      "content": "GitHub 이슈 #44 수정: crew-agent-runner.mjs의 dispatch 경로에서 AUTO_GIT_DIFF 플레이스홀더를 실제 git diff로 치환하는 로직 구현. request 파일의 content 필드에 \"AUTO_GIT_DIFF\" 값이 있으면 runner가 현재 git diff를 생성하여 치환한 후 에이전트에게 전달해야 함. codex provider 경로 포함 모든 dispatch 경로에서 동작해야 함."
+    }
+  ],
+  "instruction": "Direct mode로 수행하라. 사용자 요청을 작은 작업 계약으로 보고 직접 탐색, 수정, 검증한다.",
+  "successGate": [
+    "요청된 작업이 완료되었다",
+    "관련 검증 명령을 실행했다",
+    "변경 파일, 검증 결과, 남은 리스크를 AgentResult artifact에 보고했다"
+  ],
+  "failureHandling": "요구사항이 불명확하거나 범위가 커지면 blocked_on_user를 반환한다. 실행 중 실패가 있으면 수정 후 재검증하고, 계속 진행할 수 없을 때 failed를 반환한다."
+}

--- a/.crew/runs/direct-20260430-152031/request.md
+++ b/.crew/runs/direct-20260430-152031/request.md
@@ -1,0 +1,20 @@
+# GitHub 이슈 #44 수정: AUTO_GIT_DIFF 플레이스홀더 치환 로직 구현
+
+## 문제
+
+crew-dev Phase 2에서 CodeReviewer를 codex dispatch로 실행할 때, request 파일의 `content` 필드에 `"AUTO_GIT_DIFF"` 값을 설정하면 이 값이 실제 git diff로 치환되지 않고 리터럴 문자열 그대로 codex 에이전트에게 전달된다.
+
+## 기대 동작
+
+request 파일의 content에 `"AUTO_GIT_DIFF"`를 넣으면, runner가 현재 git diff를 생성하여 해당 값을 실제 diff 내용으로 치환한 후 codex 에이전트에게 전달해야 한다.
+
+## 수정 대상
+
+- `scripts/crew-agent-runner.mjs` — dispatch 경로에서 AUTO_GIT_DIFF 플레이스홀더 감지 및 치환 로직 추가
+- codex provider 경로 포함 모든 dispatch 경로에서 동작해야 함
+
+## 참고
+
+- request-file의 `inputs[].content` 필드에서 `"AUTO_GIT_DIFF"` 값을 감지
+- `git diff HEAD~1` 또는 staged/unstaged diff를 생성하여 치환
+- 치환은 runner의 prepare 또는 dispatch 단계에서 수행

--- a/.crew/runs/direct-20260430-152031/result.md
+++ b/.crew/runs/direct-20260430-152031/result.md
@@ -1,0 +1,23 @@
+# Result
+
+Status: complete
+
+## Summary
+
+Implemented `AUTO_GIT_DIFF` expansion in the shared Codex dispatch path. When any `request.inputs[].content` is exactly `AUTO_GIT_DIFF`, the runner now replaces it with generated git diff content before rendering the prompt sent to the Codex companion.
+
+## Changed Files
+
+- `scripts/lib/dispatch.mjs`
+- `tests/runner/dispatch.test.mjs`
+- `.crew/plans/direct-20260430-152031/dev-log.md`
+- `.crew/runs/direct-20260430-152031/result.md`
+
+## Verification
+
+- Passed: `npm test -- tests/runner/dispatch.test.mjs --configLoader runner`
+- Full suite: `npm test -- --configLoader runner` produced 107 passing tests and 1 unrelated failure in `tests/runner/prepare.test.mjs`, where the test expects `plan-evaluator` to be a Claude provider role while the current catalog resolves it as Codex.
+
+## Remaining Risk
+
+- Diff generation requires running inside a git worktree. If neither staged/unstaged changes nor `HEAD~1` diff are available, the placeholder is replaced with a clear `No git diff available` message.

--- a/scripts/lib/dispatch.mjs
+++ b/scripts/lib/dispatch.mjs
@@ -1,7 +1,8 @@
-import { spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
 import { persistCrewArtifact, ArtifactPersistError } from "./artifacts.mjs";
@@ -11,6 +12,8 @@ import { renderPrompt } from "./render.mjs";
 const DEFAULT_COMPANION = fileURLToPath(
   new URL("../crew-codex-companion.mjs", import.meta.url)
 );
+const execFileAsync = promisify(execFile);
+const AUTO_GIT_DIFF = "AUTO_GIT_DIFF";
 const AGENT_RESULT_STATUSES = new Set([
   "complete",
   "blocked_on_user",
@@ -33,6 +36,70 @@ export function formatDispatchProviderGuardMessage(role, provider) {
   return `dispatch is for Codex provider only. Resolved provider for role '${role}' is '${provider}'. Use 'render' + Agent tool for Claude provider (see crew-agent-runner SKILL.md).`;
 }
 
+export async function resolveAutoGitDiffInputs(request, options = {}) {
+  if (!hasAutoGitDiffInput(request)) {
+    return request;
+  }
+
+  const diff =
+    options.diff ??
+    (await generateAutoGitDiff({ cwd: options.cwd ?? process.cwd() }));
+
+  return {
+    ...request,
+    inputs: request.inputs.map((item) => {
+      if (item?.content !== AUTO_GIT_DIFF) {
+        return item;
+      }
+
+      return {
+        ...item,
+        content: diff
+      };
+    })
+  };
+}
+
+export function hasAutoGitDiffInput(request) {
+  return Array.isArray(request?.inputs)
+    ? request.inputs.some((item) => item?.content === AUTO_GIT_DIFF)
+    : false;
+}
+
+export async function generateAutoGitDiff({ cwd = process.cwd() } = {}) {
+  await git(["rev-parse", "--is-inside-work-tree"], cwd);
+
+  const [staged, unstaged] = await Promise.all([
+    git(["diff", "--no-ext-diff", "--staged"], cwd),
+    git(["diff", "--no-ext-diff"], cwd)
+  ]);
+
+  const sections = [
+    ["staged", staged],
+    ["unstaged", unstaged]
+  ]
+    .filter(([, content]) => content.trim().length > 0)
+    .map(([label, content]) => `# git diff (${label})\n${content.trimEnd()}`);
+
+  if (sections.length > 0) {
+    return sections.join("\n\n");
+  }
+
+  try {
+    const previousCommitDiff = await git(
+      ["diff", "--no-ext-diff", "HEAD~1"],
+      cwd
+    );
+    if (previousCommitDiff.trim().length > 0) {
+      return `# git diff (HEAD~1)\n${previousCommitDiff.trimEnd()}`;
+    }
+  } catch {
+    // Repositories with fewer than two commits have no HEAD~1 fallback.
+  }
+
+  return "# git diff\nNo git diff available.";
+}
+
 export async function dispatch(input) {
   if (input.resolved?.provider !== "codex") {
     throw new DispatchError(
@@ -46,6 +113,7 @@ export async function dispatch(input) {
 
   const companion = resolveCompanion(input);
   await assertResumeCandidate(input.resumeHandle, companion);
+  const request = await resolveAutoGitDiffInputs(input.request);
 
   const tmpDir = await mkdtemp(join(tmpdir(), "claude-crew-dispatch-"));
   const promptFile = join(tmpDir, `${input.role}-prompt.md`);
@@ -55,7 +123,7 @@ export async function dispatch(input) {
       promptFile,
       renderPrompt({
         role: input.role,
-        request: input.request,
+        request,
         contract: input.contract
       }),
       "utf8"
@@ -135,6 +203,15 @@ export async function runCompanion(companion, args) {
       });
     });
   });
+}
+
+async function git(args, cwd) {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024
+  });
+  return stdout;
 }
 
 async function assertResumeCandidate(resumeHandle, companion) {

--- a/tests/runner/dispatch.test.mjs
+++ b/tests/runner/dispatch.test.mjs
@@ -1,11 +1,14 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { afterEach, describe, expect, test } from "vitest";
 
 import { cleanupTmpDir, mkTmpDir } from "../_helpers/fs.mjs";
-import { dispatch } from "../../scripts/lib/dispatch.mjs";
+import {
+  dispatch,
+  resolveAutoGitDiffInputs
+} from "../../scripts/lib/dispatch.mjs";
 
 let tmpDir;
 
@@ -34,18 +37,19 @@ function requestFixture() {
   };
 }
 
-async function writeRequest() {
+async function writeRequest(request = requestFixture()) {
   tmpDir = await mkTmpDir();
   const requestPath = join(tmpDir, "request.json");
-  await writeFile(requestPath, JSON.stringify(requestFixture()), "utf8");
+  await writeFile(requestPath, JSON.stringify(request), "utf8");
   return requestPath;
 }
 
-function runDispatch(args, env = {}) {
+function runDispatch(args, env = {}, options = {}) {
   return spawnSync(
     process.execPath,
-    ["scripts/crew-agent-runner.mjs", "dispatch", ...args],
+    [resolve("scripts/crew-agent-runner.mjs"), "dispatch", ...args],
     {
+      cwd: options.cwd ?? process.cwd(),
       encoding: "utf8",
       env: {
         ...process.env,
@@ -66,6 +70,25 @@ async function readLog(path) {
 }
 
 describe("crew-agent-runner dispatch CLI", () => {
+  test("replaces exact AUTO_GIT_DIFF input content without mutating other inputs", async () => {
+    const request = {
+      ...requestFixture(),
+      inputs: [
+        { path: ".crew/plans/task-123/diff.md", content: "AUTO_GIT_DIFF" },
+        { path: ".crew/plans/task-123/notes.md", content: "AUTO_GIT_DIFF plus notes" }
+      ]
+    };
+
+    const resolved = await resolveAutoGitDiffInputs(request, {
+      diff: "diff --git a/file.txt b/file.txt"
+    });
+
+    expect(resolved).not.toBe(request);
+    expect(resolved.inputs[0].content).toBe("diff --git a/file.txt b/file.txt");
+    expect(resolved.inputs[1].content).toBe("AUTO_GIT_DIFF plus notes");
+    expect(request.inputs[0].content).toBe("AUTO_GIT_DIFF");
+  });
+
   test("runs companion with a prompt file and returns AgentResult with agent_handle", async () => {
     const requestPath = await writeRequest();
     const logPath = join(tmpDir, "fake-companion.log");
@@ -96,12 +119,47 @@ describe("crew-agent-runner dispatch CLI", () => {
     expect(call.prompt).toContain("Implement the dispatch command.");
   });
 
+  test("expands AUTO_GIT_DIFF before rendering the Codex dispatch prompt", async () => {
+    const requestPath = await writeRequest({
+      ...requestFixture(),
+      inputs: [
+        {
+          path: ".crew/plans/task-123/diff.md",
+          content: "AUTO_GIT_DIFF"
+        }
+      ]
+    });
+    const logPath = join(tmpDir, "fake-companion.log");
+
+    const result = runDispatch(
+      ["--role", "dev", "--request-file", requestPath, "--json", "--no-checkpoint"],
+      { FAKE_COMPANION_RESPONSE: "complete", FAKE_COMPANION_LOG: logPath }
+    );
+
+    expect(result.status).toBe(0);
+
+    const [call] = await readLog(logPath);
+    expect(call.prompt).toContain("### .crew/plans/task-123/diff.md");
+    expect(call.prompt).toContain("# git diff");
+  });
+
   test("rejects claude provider roles with a dispatch-specific usage error", async () => {
     const requestPath = await writeRequest();
+    await mkdir(join(tmpDir, ".crew"), { recursive: true });
+    await writeFile(
+      join(tmpDir, ".crew", "config.json"),
+      JSON.stringify({
+        agent_defaults: {
+          qa: { provider: "claude", model: "sonnet" }
+        }
+      }),
+      "utf8"
+    );
 
     const result = runDispatch(
       ["--role", "qa", "--request-file", requestPath, "--json"],
-      { FAKE_COMPANION_RESPONSE: "complete" }
+      { FAKE_COMPANION_RESPONSE: "complete" },
+      { cwd: tmpDir }
     );
 
     expect(result.status).toBe(2);


### PR DESCRIPTION
## Summary
- dispatch 경로에서 `request.inputs[].content`가 `"AUTO_GIT_DIFF"`이면 실제 git diff(staged/unstaged, fallback HEAD~1)로 치환하여 codex 에이전트에 전달
- 원본 request 객체 불변 유지 (immutability)
- 유닛 + 통합 테스트 2건 추가, dispatch 테스트 11건 전체 통과

Closes #44

## Test plan
- [x] `npm test -- tests/runner/dispatch.test.mjs` — 11 passed
- [ ] crew-dev Phase 2에서 CodeReviewer codex dispatch 시 AUTO_GIT_DIFF가 실제 diff로 치환되는지 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)