### PR TITLE
feat: 컨텍스트 한계 도달 시 crew 워크플로우 상태 보존/복구 (#46)

### DIFF
--- a/.crew/plans/direct-20260430-152417/dev-log.md
+++ b/.crew/plans/direct-20260430-152417/dev-log.md
@@ -1,0 +1,23 @@
+# Dev Log
+
+Task: GitHub Issue #46 context checkpoint preservation and restore.
+
+## Implemented
+
+- Added `lib/crew-state.mjs` with `readRunState`, `writeRunState`, `createCheckpoint`, and `getLatestCheckpoint`.
+- Added `scripts/crew-pre-compact.mjs` to save a checkpoint and return a PreCompact restore summary.
+- Added `scripts/crew-context-guard-stop.mjs` to block near-full context Stop events at 75%-95%, with bypass reasons and per-session block limit.
+- Added `scripts/crew-session-restore.mjs` to inject active run restore context from current state or latest checkpoint.
+- Wired `PreCompact`, `Stop`, and SessionStart restore hooks in `hooks/hooks.json`.
+- Added `lib/` to `package.json` package files so the new state helper ships with the plugin.
+- Added focused tests for state helpers, checkpoint creation, context guard blocking/bypass, restore messages, and PreCompact checkpoint summary.
+
+## Verification
+
+- `node --check scripts/crew-pre-compact.mjs && node --check scripts/crew-context-guard-stop.mjs && node --check scripts/crew-session-restore.mjs && node --check lib/crew-state.mjs` passed.
+- `npm test -- --run --config /tmp/claude-crew-vitest.config.mjs tests/runner/crewState.test.mjs tests/hooks/contextCheckpoint.test.mjs` passed: 2 files, 7 tests.
+
+## Notes
+
+- Running Vitest with the repo config attempted to write Vite temp config under the parent repo `node_modules/.vite-temp`, outside the writable sandbox. A temp config under `/tmp` was used for verification.
+- The full suite under the temp config had two unrelated existing failures where provider defaults resolve `plan-evaluator`/`qa` as Codex while older tests expect Claude.

--- a/.crew/plans/direct-20260430-160411/dev-log.md
+++ b/.crew/plans/direct-20260430-160411/dev-log.md
@@ -1,0 +1,31 @@
+# Dev Log
+
+## Summary
+
+- Updated CLI tests that implicitly depended on catalog defaults to write project-level `.crew/config.json` overrides.
+- Scoped changes to CLI tests in `prepare.test.mjs`, `dispatch.test.mjs`, and `resolve.test.mjs`.
+- Left lib-level tests unchanged.
+
+## Changes
+
+- `tests/runner/prepare.test.mjs`
+  - Added a `writeProjectConfig` helper.
+  - Added explicit `dev` provider override: `codex` / `gpt-5.5` / `medium`.
+  - Ran Codex prepare CLI cases with `cwd: tmpDir`.
+  - Updated expected dispatch command path to use `REPO_ROOT`.
+
+- `tests/runner/dispatch.test.mjs`
+  - Added project config helpers.
+  - Added explicit `dev` provider override for targeted dispatch CLI tests.
+  - Ran targeted dispatch CLI invocations with `cwd: tmpDir`.
+  - Reused the project config helper for the existing Claude `qa` rejection case.
+
+- `tests/runner/resolve.test.mjs`
+  - Added `REPO_ROOT`.
+  - Added explicit `planner` provider override: `codex` / `gpt-5.5` / `medium`.
+  - Ran the planner resolve CLI case with `cwd: tmpDir` and an absolute runner script path.
+
+## Verification
+
+- `npx vitest run`
+- Result: 23 test files passed, 113 tests passed.

--- a/.crew/runs/direct-20260430-152417/request.json
+++ b/.crew/runs/direct-20260430-152417/request.json
@@ -1,0 +1,30 @@
+{
+  "role": "dev",
+  "mode": "direct",
+  "taskId": "direct-20260430-152417",
+  "inputs": [
+    {
+      "path": ".crew/runs/direct-20260430-152417/request.md",
+      "content": "GitHub Issue #46: 컨텍스트 한계 도달 시 crew 워크플로우 상태 보존/복구. 상세 내용은 request.md 참조."
+    },
+    {
+      "path": "request.mode",
+      "content": "direct"
+    },
+    {
+      "path": "request.task",
+      "content": "GitHub 이슈 #46을 구현하라. 1) lib/crew-state.mjs에 run state read/write/checkpoint helper 추가 2) scripts/crew-pre-compact.mjs 구현 (PreCompact hook) 3) scripts/crew-context-guard-stop.mjs 구현 (Stop context guard) 4) scripts/crew-session-restore.mjs 구현 (SessionStart restore) 5) hooks/hooks.json에 PreCompact, Stop, SessionStart restore hook 연결 6) 테스트 추가. 상세 스키마와 동작은 .crew/runs/direct-20260430-152417/request.md 참조."
+    }
+  ],
+  "instruction": "Direct mode로 수행하라. .crew/runs/direct-20260430-152417/request.md의 상세 요구사항을 작업 계약으로 사용한다. plugin 자체 파일(lib/, scripts/, hooks/)은 import.meta.url 또는 $CLAUDE_PLUGIN_ROOT 기반 경로를 사용하고, 사용자 데이터(.crew/state/)는 cwd 기준으로 접근한다.",
+  "successGate": [
+    "lib/crew-state.mjs가 추가되어 readRunState, writeRunState, createCheckpoint, getLatestCheckpoint helper가 동작한다",
+    "scripts/crew-pre-compact.mjs가 추가되어 PreCompact hook으로 checkpoint 저장 및 systemMessage를 반환한다",
+    "scripts/crew-context-guard-stop.mjs가 추가되어 Stop hook으로 context guard가 동작한다",
+    "scripts/crew-session-restore.mjs가 추가되어 SessionStart restore context를 주입한다",
+    "hooks/hooks.json에 PreCompact, Stop, SessionStart 항목이 추가되었다",
+    "테스트가 추가되어 통과한다",
+    "변경 파일, 검증 결과, 남은 리스크를 AgentResult artifact에 보고했다"
+  ],
+  "failureHandling": "요구사항이 불명확하거나 범위가 커지면 blocked_on_user를 반환한다. 실행 중 실패가 있으면 수정 후 재검증하고, 계속 진행할 수 없을 때 failed를 반환한다."
+}

--- a/.crew/runs/direct-20260430-152417/request.md
+++ b/.crew/runs/direct-20260430-152417/request.md
@@ -1,0 +1,151 @@
+# GitHub Issue #46: 컨텍스트 한계 도달 시 crew 워크플로우 상태 보존/복구
+
+## 요약
+
+claude-crew 워크플로우 진행 중 컨텍스트가 가득 차면 현재 phase/pending agent result/artifact 위치 등이 유실된다.
+PreCompact/Stop/SessionStart 훅을 추가하여 상태를 보존하고 복구할 수 있게 한다.
+
+## 구현 항목
+
+### 1. crew run state 저장 (`lib/crew-state.mjs`)
+
+`.crew/state/current-run.json` 스키마와 read/write helper를 추가한다.
+
+최소 필드:
+```json
+{
+  "version": 1,
+  "active": true,
+  "workflow": "crew-dev",
+  "phase": "qa",
+  "taskId": "TASK-123",
+  "taskFile": ".crew/tasks/TASK-123.md",
+  "activeRole": "qa",
+  "pendingStatus": "needs_agent",
+  "pendingAgentResultPath": ".crew/artifacts/qa-result.json",
+  "artifactPaths": [".crew/artifacts/dev-result.json"],
+  "agentHandles": { "dev": "thread-or-agent-id" },
+  "codexThreadIds": { "dev": "thread-id" },
+  "lastUpdatedAt": "2026-04-30T00:00:00.000Z"
+}
+```
+
+helper 함수:
+- `readRunState(crewDir)` — current-run.json을 읽어 반환 (없으면 null)
+- `writeRunState(crewDir, state)` — state를 current-run.json에 atomic write (immutable — 새 객체 반환)
+- `createCheckpoint(crewDir)` — current-run.json을 `.crew/state/checkpoints/checkpoint-<ISO timestamp>.json`에 복사
+- `getLatestCheckpoint(crewDir)` — 최신 checkpoint 파일 경로 반환 (없으면 null)
+
+### 2. PreCompact hook (`scripts/crew-pre-compact.mjs`)
+
+hooks/hooks.json에 PreCompact hook을 추가한다.
+
+```json
+{
+  "type": "command",
+  "command": "node \"$CLAUDE_PLUGIN_ROOT/scripts/crew-pre-compact.mjs\"",
+  "timeout": 10
+}
+```
+
+스크립트 동작:
+- hook stdin JSON 파싱
+- current run state 읽기 (없으면 빈 systemMessage 반환)
+- `.crew/state/checkpoints/checkpoint-<timestamp>.json` 저장
+- compact 이후 보존할 요약 systemMessage 반환
+
+systemMessage 형식:
+```markdown
+# Crew PreCompact Checkpoint
+
+Workflow: crew-dev
+Phase: qa
+Task: .crew/tasks/TASK-123.md
+Active role: qa
+Pending: qa verification
+Artifacts:
+- .crew/artifacts/dev-result.json
+Resume handles:
+- dev: thread-or-agent-id
+
+After compaction, inspect the checkpoint and continue from the pending phase unless the user's newest request overrides it.
+```
+
+### 3. Stop context guard (`scripts/crew-context-guard-stop.mjs`)
+
+hooks/hooks.json에 Stop hook을 추가한다.
+
+```json
+{
+  "type": "command",
+  "command": "node \"$CLAUDE_PLUGIN_ROOT/scripts/crew-context-guard-stop.mjs\"",
+  "timeout": 5
+}
+```
+
+스크립트 동작:
+- stdin에서 stop_hook_input JSON 파싱
+- transcript tail에서 context_window, input_tokens 추정
+- 75% 이상이면 `/compact` 실행을 요구하는 systemMessage와 함께 `{ "decision": "block" }` 반환
+- 다음은 절대 block하지 않음:
+  - context_limit, context_window, context_full, max_tokens, conversation_too_long 등의 stop reason
+  - user abort/cancel/interrupt
+  - auth error
+- session별 block 횟수 제한 (최대 2회). 임시 파일로 카운트 관리 (`/tmp/crew-stop-guard-{session-id}.json`)
+- 95% 이상 critical 구간도 block하지 않음
+
+### 4. SessionStart restore (`scripts/crew-session-restore.mjs`)
+
+기존 SessionStart hook에 restore 스크립트를 추가한다.
+
+스크립트 동작:
+- `.crew/state/current-run.json` 또는 최신 checkpoint 읽기
+- active run이 있으면 restore context systemMessage 반환
+- 없으면 빈 응답
+
+restore message 형식:
+```markdown
+<crew-session-restore>
+Active crew workflow detected.
+
+Workflow: crew-dev
+Phase: qa
+Task: .crew/tasks/TASK-123.md
+Pending: qa verification
+Last artifact: .crew/artifacts/dev-result.json
+Checkpoint: .crew/state/checkpoints/checkpoint-2026-04-30T00-00-00.json
+
+Treat this as prior-session context. Prioritize the user's newest request. Resume the crew workflow only if the user asks to continue.
+</crew-session-restore>
+```
+
+### 5. hooks/hooks.json 연결
+
+기존 hooks.json에 PreCompact, Stop, SessionStart restore 항목을 추가한다.
+
+### 6. 기존 resume 규약 재사용
+
+Checkpoint에 기존 runner가 필요로 하는 값을 보존:
+- Codex: agent_handle / thread id, previous AgentResult path, followup input path, role
+- Claude: sub-agent handle, previous result, followup prompt 생성 입력
+
+복구 시 기존 `render-followup` / `dispatch --resume-handle` 재사용.
+
+### 7. 테스트 추가
+
+- checkpoint 생성 테스트
+- context guard block 테스트
+- context_limit bypass 테스트
+- restore message 생성 테스트
+- run state read/write 테스트
+
+## 파일 구조
+
+plugin 자체 데이터이므로 `import.meta.url` 또는 `$CLAUDE_PLUGIN_ROOT` 기반 경로 사용.
+사용자 데이터(`.crew/state/`)는 cwd 기준.
+
+## 참고
+
+- 유저 대신 `/compact`를 자동 실행하지 않음
+- OMC 전체 구조를 복제하지 않음
+- 기존 provider dispatch/resume 규약을 새로 설계하지 않음

--- a/.crew/runs/direct-20260430-152417/result.md
+++ b/.crew/runs/direct-20260430-152417/result.md
@@ -1,0 +1,30 @@
+# AgentResult
+
+Status: complete
+
+## Summary
+
+Implemented context checkpoint preservation and restore for crew workflows.
+
+## Changed Files
+
+- `lib/crew-state.mjs`
+- `scripts/crew-pre-compact.mjs`
+- `scripts/crew-context-guard-stop.mjs`
+- `scripts/crew-session-restore.mjs`
+- `hooks/hooks.json`
+- `package.json`
+- `tests/runner/crewState.test.mjs`
+- `tests/hooks/contextCheckpoint.test.mjs`
+- `.crew/plans/direct-20260430-152417/dev-log.md`
+- `.crew/runs/direct-20260430-152417/result.md`
+
+## Verification
+
+- Syntax check passed for all new runtime modules.
+- Focused test run passed: `tests/runner/crewState.test.mjs` and `tests/hooks/contextCheckpoint.test.mjs`, 7 tests total.
+
+## Remaining Risks
+
+- Normal `vitest` config loading is blocked in this sandbox because Vite writes temp files outside the worktree.
+- Full-suite temp-config run has unrelated provider-resolution expectation failures in existing `prepare` and `dispatch` tests.

--- a/.crew/runs/direct-20260430-160411/request.json
+++ b/.crew/runs/direct-20260430-160411/request.json
@@ -1,0 +1,28 @@
+{
+  "role": "dev",
+  "mode": "direct",
+  "taskId": "direct-20260430-160411",
+  "inputs": [
+    {
+      "path": ".crew/runs/direct-20260430-160411/request.md",
+      "content": "카탈로그 기본값에 암묵적으로 의존하는 CLI 테스트에 project config override 적용"
+    },
+    {
+      "path": "request.mode",
+      "content": "direct"
+    },
+    {
+      "path": "request.task",
+      "content": "tests/runner/prepare.test.mjs, tests/runner/dispatch.test.mjs, tests/runner/resolve.test.mjs의 CLI 테스트에서 카탈로그 기본값에 암묵적으로 의존하는 부분을 project config override 패턴으로 수정하라. 상세 대상과 패턴은 .crew/runs/direct-20260430-160411/request.md 참조."
+    }
+  ],
+  "instruction": "Direct mode로 수행하라. request.md의 수정 대상 목록과 패턴을 작업 계약으로 사용한다. lib 레벨 테스트는 수정하지 않는다. CLI 테스트만 수정한다. 수정 후 npx vitest run으로 전체 통과를 확인한다.",
+  "successGate": [
+    "prepare.test.mjs의 codex provider CLI 테스트에 project config override가 적용되었다",
+    "dispatch.test.mjs의 dev role CLI 테스트에 project config override가 적용되었다",
+    "resolve.test.mjs의 planner role CLI 테스트에 project config override가 적용되었다",
+    "npx vitest run 전체 통과",
+    "변경 파일, 검증 결과를 AgentResult artifact에 보고했다"
+  ],
+  "failureHandling": "테스트가 깨지면 원인을 분석하고 수정 후 재검증한다. 해결 불가능하면 failed를 반환한다."
+}

--- a/.crew/runs/direct-20260430-160411/request.md
+++ b/.crew/runs/direct-20260430-160411/request.md
@@ -1,0 +1,49 @@
+# 카탈로그 기본값에 암묵적으로 의존하는 CLI 테스트에 project config override 적용
+
+## 배경
+
+`provider-catalog.json`의 `agent_defaults`가 변경되면 CLI 테스트가 깨진다.
+방금 `plan-evaluator`(claude→codex)와 `qa`(claude→codex) 테스트를 project config override 패턴으로 수정했다.
+이 패턴을 나머지 카탈로그 의존 CLI 테스트에도 적용한다.
+
+## 패턴
+
+각 CLI 테스트에서 tmpDir에 `.crew/config.json`을 생성하여 테스트할 role의 provider를 명시적으로 선언하고, `cwd: tmpDir`로 실행한다.
+
+이미 적용된 예시 (prepare.test.mjs의 Claude 테스트):
+```js
+await mkdir(join(tmpDir, ".crew"), { recursive: true });
+await writeFile(
+  join(tmpDir, ".crew", "config.json"),
+  JSON.stringify({
+    providers: { "plan-evaluator": { provider: "claude", model: "sonnet" } }
+  }),
+  "utf8"
+);
+const result = runPrepare([...args], { cwd: tmpDir });
+```
+
+## 수정 대상
+
+### prepare.test.mjs
+- "returns a dispatch action for Codex provider roles" — `dev`가 codex라고 가정. project config로 `dev: codex/gpt-5.5/medium` 명시 + `cwd: tmpDir`
+- "prints the dispatch command in text mode" — 동일
+
+### dispatch.test.mjs  
+- "runs companion with a prompt file..." — `dev`가 codex라고 가정. override 필요
+- "adds --write for workspace-write..." — 동일
+- "uses --resume-last only when..." — 동일
+- "rejects a resume handle..." — 동일
+- "exits non-zero with a diagnostic..." — 동일
+
+### resolve.test.mjs
+- "prints JSON for planner role" — `planner`가 codex라고 가정. override 필요
+
+## 주의사항
+
+- lib 레벨 테스트 (dispatch.mjs의 `dispatch()` 직접 호출)는 이미 explicit `resolved` 객체를 전달하므로 수정 불필요
+- resolve.test.mjs의 `resolveRole` 단위 테스트도 explicit fixture catalog를 사용하므로 수정 불필요
+- runPrepare, runDispatch 함수는 이미 options 파라미터와 REPO_ROOT 기반 절대 경로를 지원함 (이전 커밋에서 수정)
+- dispatch 테스트의 command 기대값에서 script 경로가 REPO_ROOT 기반인지 확인
+- prepare 테스트의 codex command 기대값에 `join(process.cwd(), ...)` → `join(REPO_ROOT, ...)` 변경 필요할 수 있음
+- 수정 후 `npx vitest run` 전체 통과 확인

--- a/.crew/runs/direct-20260430-160411/result.md
+++ b/.crew/runs/direct-20260430-160411/result.md
@@ -1,0 +1,20 @@
+# Result
+
+Status: complete
+
+## Summary
+
+Applied project config override patterns to the requested CLI tests so they no longer rely on catalog defaults for `dev` or `planner`.
+
+## Changed Files
+
+- `tests/runner/prepare.test.mjs`
+- `tests/runner/dispatch.test.mjs`
+- `tests/runner/resolve.test.mjs`
+- `.crew/plans/direct-20260430-160411/dev-log.md`
+- `.crew/runs/direct-20260430-160411/result.md`
+
+## Verification
+
+- `npx vitest run`
+- Passed: 23 test files, 113 tests.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,36 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"$CLAUDE_PLUGIN_ROOT/scripts/crew-session-restore.mjs\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT/scripts/setup-hud.mjs\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PLUGIN_ROOT/scripts/crew-pre-compact.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PLUGIN_ROOT/scripts/crew-context-guard-stop.mjs\"",
             "timeout": 5
           }
         ]

--- a/lib/crew-state.mjs
+++ b/lib/crew-state.mjs
@@ -1,0 +1,72 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const STATE_VERSION = 1;
+const CURRENT_RUN_FILE = "current-run.json";
+
+export function currentRunPath(crewDir) {
+  return join(crewDir, "state", CURRENT_RUN_FILE);
+}
+
+export function checkpointsDir(crewDir) {
+  return join(crewDir, "state", "checkpoints");
+}
+
+export async function readRunState(crewDir) {
+  const path = currentRunPath(crewDir);
+  if (!existsSync(path)) return null;
+
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    throw new Error(`Failed to read crew run state at ${path}: ${error.message}`);
+  }
+}
+
+export async function writeRunState(crewDir, state) {
+  const stateDir = join(crewDir, "state");
+  await mkdir(stateDir, { recursive: true });
+
+  const nextState = {
+    ...state,
+    version: state.version ?? STATE_VERSION,
+    lastUpdatedAt: new Date().toISOString()
+  };
+
+  const destination = currentRunPath(crewDir);
+  const tempPath = join(
+    stateDir,
+    `.${CURRENT_RUN_FILE}.${process.pid}.${Date.now()}.tmp`
+  );
+
+  await writeFile(tempPath, `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  await rename(tempPath, destination);
+  return nextState;
+}
+
+export async function createCheckpoint(crewDir) {
+  const state = await readRunState(crewDir);
+  if (!state) return null;
+
+  const dir = checkpointsDir(crewDir);
+  await mkdir(dir, { recursive: true });
+
+  const timestamp = new Date().toISOString().replace(/:/g, "-");
+  const checkpointPath = join(dir, `checkpoint-${timestamp}.json`);
+  await writeFile(checkpointPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  return checkpointPath;
+}
+
+export async function getLatestCheckpoint(crewDir) {
+  const dir = checkpointsDir(crewDir);
+  if (!existsSync(dir)) return null;
+
+  const { readdir } = await import("node:fs/promises");
+  const files = (await readdir(dir))
+    .filter((file) => /^checkpoint-.+\.json$/.test(file))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (files.length === 0) return null;
+  return join(dir, basename(files.at(-1)));
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ".claude-plugin/",
     "agents/",
     "data/",
+    "lib/",
     "skills/",
     "hooks/",
     "hud/",

--- a/scripts/crew-context-guard-stop.mjs
+++ b/scripts/crew-context-guard-stop.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const BYPASS_REASONS = [
+  "context_limit",
+  "context_window",
+  "context_full",
+  "max_tokens",
+  "conversation_too_long",
+  "abort",
+  "cancel",
+  "interrupt",
+  "auth"
+];
+
+async function readStdin(timeoutMs = 3000) {
+  if (process.stdin.isTTY) return null;
+  return new Promise((resolve) => {
+    let data = "";
+    const timer = setTimeout(() => resolve(data || null), timeoutMs);
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { data += chunk; });
+    process.stdin.on("end", () => {
+      clearTimeout(timer);
+      resolve(data || null);
+    });
+    process.stdin.on("error", () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+  });
+}
+
+function pass() {
+  return { continue: true };
+}
+
+function sessionId(event) {
+  return String(event.session_id || event.sessionId || event.session?.id || "unknown")
+    .replace(/[^a-zA-Z0-9_.-]/g, "_");
+}
+
+function reasonText(event) {
+  return [
+    event.stop_reason,
+    event.stopReason,
+    event.reason,
+    event.error,
+    event.message
+  ].filter(Boolean).join(" ").toLowerCase();
+}
+
+function shouldBypass(event) {
+  const text = reasonText(event);
+  return BYPASS_REASONS.some((reason) => text.includes(reason));
+}
+
+function collectUsage(value, found = { inputTokens: null, contextWindow: null }) {
+  if (!value || typeof value !== "object") return found;
+
+  for (const [key, nested] of Object.entries(value)) {
+    const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (
+      ["inputtokens", "inputtoken", "tokensinput", "totalinputtokens"].includes(normalized)
+      && Number.isFinite(Number(nested))
+    ) {
+      found.inputTokens = Math.max(found.inputTokens ?? 0, Number(nested));
+    }
+    if (
+      ["contextwindow", "contextwindowsize", "contextlimit", "maxcontexttokens"].includes(normalized)
+      && Number.isFinite(Number(nested))
+    ) {
+      found.contextWindow = Math.max(found.contextWindow ?? 0, Number(nested));
+    }
+    collectUsage(nested, found);
+  }
+
+  return found;
+}
+
+function parseUsageFromText(text) {
+  const inputMatches = [...text.matchAll(/"?(?:input_tokens|inputTokens|inputToken|total_input_tokens)"?\s*[:=]\s*(\d+)/gi)];
+  const windowMatches = [...text.matchAll(/"?(?:context_window|contextWindow|context_limit|max_context_tokens)"?\s*[:=]\s*(\d+)/gi)];
+
+  return {
+    inputTokens: inputMatches.length > 0 ? Math.max(...inputMatches.map((match) => Number(match[1]))) : null,
+    contextWindow: windowMatches.length > 0 ? Math.max(...windowMatches.map((match) => Number(match[1]))) : null
+  };
+}
+
+async function usageFromTranscript(event) {
+  const transcriptPath = event.transcript_path || event.transcriptPath;
+  if (!transcriptPath || !existsSync(transcriptPath)) {
+    return { inputTokens: null, contextWindow: null };
+  }
+
+  try {
+    const text = await readFile(transcriptPath, "utf8");
+    return parseUsageFromText(text.slice(-128 * 1024));
+  } catch {
+    return { inputTokens: null, contextWindow: null };
+  }
+}
+
+async function usageFor(event) {
+  const fromEvent = collectUsage(event);
+  const fromTranscript = await usageFromTranscript(event);
+  return {
+    inputTokens: fromEvent.inputTokens ?? fromTranscript.inputTokens,
+    contextWindow: fromEvent.contextWindow ?? fromTranscript.contextWindow
+  };
+}
+
+function counterPath(id) {
+  return join(tmpdir(), `crew-stop-guard-${id}.json`);
+}
+
+async function readCount(id) {
+  const path = counterPath(id);
+  if (!existsSync(path)) return 0;
+  try {
+    const payload = JSON.parse(await readFile(path, "utf8"));
+    return Number(payload.count) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function writeCount(id, count) {
+  await writeFile(
+    counterPath(id),
+    `${JSON.stringify({ count, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+function blockMessage(percent) {
+  return [
+    "Crew context guard: this session appears to be near the context window.",
+    `Estimated usage: ${Math.round(percent)}%.`,
+    "Run /compact before continuing so the crew workflow can checkpoint and preserve pending role, artifacts, and resume handles."
+  ].join("\n");
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw) {
+    console.log(JSON.stringify(pass()));
+    return;
+  }
+
+  let event;
+  try { event = JSON.parse(raw); } catch {
+    console.log(JSON.stringify(pass()));
+    return;
+  }
+
+  if (shouldBypass(event)) {
+    console.log(JSON.stringify(pass()));
+    return;
+  }
+
+  const { inputTokens, contextWindow } = await usageFor(event);
+  if (!inputTokens || !contextWindow) {
+    console.log(JSON.stringify(pass()));
+    return;
+  }
+
+  const percent = (inputTokens / contextWindow) * 100;
+  if (percent < 75 || percent >= 95) {
+    console.log(JSON.stringify(pass()));
+    return;
+  }
+
+  const id = sessionId(event);
+  const count = await readCount(id);
+  if (count >= 2) {
+    console.log(JSON.stringify(pass()));
+    return;
+  }
+
+  await writeCount(id, count + 1);
+  const message = blockMessage(percent);
+  console.log(JSON.stringify({
+    continue: true,
+    decision: "block",
+    reason: message,
+    systemMessage: message,
+    hookSpecificOutput: {
+      hookEventName: "Stop",
+      additionalContext: message
+    }
+  }));
+}
+
+main();

--- a/scripts/crew-pre-compact.mjs
+++ b/scripts/crew-pre-compact.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { relative, resolve } from "node:path";
+
+import { createCheckpoint, readRunState } from "../lib/crew-state.mjs";
+
+async function readStdin(timeoutMs = 3000) {
+  if (process.stdin.isTTY) return null;
+  return new Promise((resolveInput) => {
+    let data = "";
+    const timer = setTimeout(() => resolveInput(data || null), timeoutMs);
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { data += chunk; });
+    process.stdin.on("end", () => {
+      clearTimeout(timer);
+      resolveInput(data || null);
+    });
+    process.stdin.on("error", () => {
+      clearTimeout(timer);
+      resolveInput(null);
+    });
+  });
+}
+
+function emptyResponse() {
+  return { continue: true };
+}
+
+function hookResponse(message) {
+  return {
+    continue: true,
+    systemMessage: message,
+    hookSpecificOutput: {
+      hookEventName: "PreCompact",
+      additionalContext: message
+    }
+  };
+}
+
+function formatPath(cwd, path) {
+  if (!path) return null;
+  if (!path.startsWith("/")) return path;
+  return relative(cwd, path) || ".";
+}
+
+function pendingText(state) {
+  return state.pendingStatus || state.pending || "none";
+}
+
+function buildMessage({ state, checkpointPath, cwd }) {
+  const artifacts = Array.isArray(state.artifactPaths) ? state.artifactPaths : [];
+  const handles = state.agentHandles && typeof state.agentHandles === "object"
+    ? Object.entries(state.agentHandles)
+    : [];
+
+  return [
+    "# Crew PreCompact Checkpoint",
+    "",
+    `Workflow: ${state.workflow || "unknown"}`,
+    `Phase: ${state.phase || "unknown"}`,
+    `Task: ${state.taskFile || state.taskId || "unknown"}`,
+    `Active role: ${state.activeRole || "unknown"}`,
+    `Pending: ${pendingText(state)}`,
+    `Checkpoint: ${formatPath(cwd, checkpointPath)}`,
+    "Artifacts:",
+    ...(artifacts.length > 0 ? artifacts.map((path) => `- ${path}`) : ["- none"]),
+    "Resume handles:",
+    ...(handles.length > 0 ? handles.map(([role, handle]) => `- ${role}: ${handle}`) : ["- none"]),
+    "",
+    "After compaction, inspect the checkpoint and continue from the pending phase unless the user's newest request overrides it."
+  ].join("\n");
+}
+
+async function main() {
+  const raw = await readStdin();
+  let event = {};
+  if (raw) {
+    try { event = JSON.parse(raw); } catch { /* ignore */ }
+  }
+
+  const cwd = resolve(event.cwd || process.cwd());
+  const crewDir = resolve(cwd, ".crew");
+
+  try {
+    const state = await readRunState(crewDir);
+    if (!state) {
+      console.log(JSON.stringify(emptyResponse()));
+      return;
+    }
+
+    const checkpointPath = await createCheckpoint(crewDir);
+    console.log(JSON.stringify(hookResponse(buildMessage({ state, checkpointPath, cwd }))));
+  } catch (error) {
+    console.log(JSON.stringify({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: "PreCompact",
+        additionalContext: `CREW checkpoint failed: ${error.message}`
+      }
+    }));
+  }
+}
+
+main();

--- a/scripts/crew-session-restore.mjs
+++ b/scripts/crew-session-restore.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+
+import { getLatestCheckpoint, readRunState } from "../lib/crew-state.mjs";
+
+async function readStdin(timeoutMs = 3000) {
+  if (process.stdin.isTTY) return null;
+  return new Promise((resolveInput) => {
+    let data = "";
+    const timer = setTimeout(() => resolveInput(data || null), timeoutMs);
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { data += chunk; });
+    process.stdin.on("end", () => {
+      clearTimeout(timer);
+      resolveInput(data || null);
+    });
+    process.stdin.on("error", () => {
+      clearTimeout(timer);
+      resolveInput(null);
+    });
+  });
+}
+
+function emptyResponse() {
+  return { continue: true };
+}
+
+function hookResponse(message) {
+  return {
+    continue: true,
+    systemMessage: message,
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: message
+    }
+  };
+}
+
+function formatPath(cwd, path) {
+  if (!path) return null;
+  if (!path.startsWith("/")) return path;
+  return relative(cwd, path) || ".";
+}
+
+function pendingText(state) {
+  return state.pendingStatus || state.pending || "none";
+}
+
+function lastArtifact(state) {
+  if (state.pendingAgentResultPath) return state.pendingAgentResultPath;
+  if (Array.isArray(state.artifactPaths) && state.artifactPaths.length > 0) {
+    return state.artifactPaths.at(-1);
+  }
+  return "none";
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function findActiveState(crewDir) {
+  const current = await readRunState(crewDir);
+  if (current?.active) {
+    return { state: current, checkpointPath: await getLatestCheckpoint(crewDir) };
+  }
+
+  const checkpointPath = await getLatestCheckpoint(crewDir);
+  if (!checkpointPath || !existsSync(checkpointPath)) return null;
+
+  const checkpoint = await readJson(checkpointPath);
+  if (!checkpoint?.active) return null;
+  return { state: checkpoint, checkpointPath };
+}
+
+function buildMessage({ state, checkpointPath, cwd }) {
+  const checkpointLine = checkpointPath
+    ? formatPath(cwd, checkpointPath)
+    : "none";
+
+  return [
+    "<crew-session-restore>",
+    "Active crew workflow detected.",
+    "",
+    `Workflow: ${state.workflow || "unknown"}`,
+    `Phase: ${state.phase || "unknown"}`,
+    `Task: ${state.taskFile || state.taskId || "unknown"}`,
+    `Pending: ${pendingText(state)}`,
+    `Last artifact: ${lastArtifact(state)}`,
+    `Checkpoint: ${checkpointLine}`,
+    "",
+    "Treat this as prior-session context. Prioritize the user's newest request. Resume the crew workflow only if the user asks to continue.",
+    "</crew-session-restore>"
+  ].join("\n");
+}
+
+async function main() {
+  const raw = await readStdin();
+  let event = {};
+  if (raw) {
+    try { event = JSON.parse(raw); } catch { /* ignore */ }
+  }
+
+  const cwd = resolve(event.cwd || process.cwd());
+  const crewDir = resolve(cwd, ".crew");
+
+  try {
+    const active = await findActiveState(crewDir);
+    if (!active) {
+      console.log(JSON.stringify(emptyResponse()));
+      return;
+    }
+
+    console.log(JSON.stringify(hookResponse(buildMessage({ ...active, cwd }))));
+  } catch (error) {
+    console.log(JSON.stringify({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: `CREW restore failed: ${error.message}`
+      }
+    }));
+  }
+}
+
+main();

--- a/tests/hooks/contextCheckpoint.test.mjs
+++ b/tests/hooks/contextCheckpoint.test.mjs
@@ -1,0 +1,119 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { writeRunState } from "../../lib/crew-state.mjs";
+import { cleanupTmpDir, mkTmpDir } from "../_helpers/fs.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const STOP_HOOK_PATH = join(REPO_ROOT, "scripts", "crew-context-guard-stop.mjs");
+const RESTORE_HOOK_PATH = join(REPO_ROOT, "scripts", "crew-session-restore.mjs");
+const PRE_COMPACT_HOOK_PATH = join(REPO_ROOT, "scripts", "crew-pre-compact.mjs");
+
+let tmpDir;
+
+afterEach(async () => {
+  if (tmpDir) {
+    await cleanupTmpDir(tmpDir);
+    tmpDir = undefined;
+  }
+});
+
+function runScript(path, event, options = {}) {
+  return spawnSync(process.execPath, [path], {
+    cwd: options.cwd ?? REPO_ROOT,
+    encoding: "utf8",
+    input: `${JSON.stringify(event)}\n`,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: REPO_ROOT
+    }
+  });
+}
+
+describe("crew context checkpoint hooks", () => {
+  test("Stop context guard blocks when estimated context usage is above threshold", () => {
+    const result = runScript(STOP_HOOK_PATH, {
+      session_id: `guard-block-${Date.now()}`,
+      usage: {
+        input_tokens: 80_000,
+        context_window: 100_000
+      }
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      continue: true,
+      decision: "block"
+    });
+    expect(payload.systemMessage).toContain("/compact");
+  });
+
+  test("Stop context guard bypasses context limit stop reasons", () => {
+    const result = runScript(STOP_HOOK_PATH, {
+      session_id: `guard-bypass-${Date.now()}`,
+      stop_reason: "context_limit",
+      usage: {
+        input_tokens: 80_000,
+        context_window: 100_000
+      }
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ continue: true });
+  });
+
+  test("SessionStart restore returns active run context", async () => {
+    tmpDir = await mkTmpDir();
+    const crewDir = join(tmpDir, ".crew");
+    await writeRunState(crewDir, {
+      active: true,
+      workflow: "crew-dev",
+      phase: "qa",
+      taskFile: ".crew/tasks/TASK-123.md",
+      pendingStatus: "qa verification",
+      artifactPaths: [".crew/artifacts/dev-result.json"]
+    });
+
+    const result = runScript(RESTORE_HOOK_PATH, { cwd: tmpDir }, { cwd: tmpDir });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const payload = JSON.parse(result.stdout);
+    expect(payload.systemMessage).toContain("<crew-session-restore>");
+    expect(payload.systemMessage).toContain("Workflow: crew-dev");
+    expect(payload.systemMessage).toContain("Phase: qa");
+    expect(payload.systemMessage).toContain("Last artifact: .crew/artifacts/dev-result.json");
+  });
+
+  test("PreCompact creates checkpoint and returns checkpoint summary", async () => {
+    tmpDir = await mkTmpDir();
+    const crewDir = join(tmpDir, ".crew");
+    await mkdir(join(tmpDir, ".crew", "artifacts"), { recursive: true });
+    await writeFile(join(tmpDir, ".crew", "artifacts", "dev-result.json"), "{}\n", "utf8");
+    await writeRunState(crewDir, {
+      active: true,
+      workflow: "crew-dev",
+      phase: "qa",
+      taskFile: ".crew/tasks/TASK-123.md",
+      activeRole: "qa",
+      pendingStatus: "qa verification",
+      artifactPaths: [".crew/artifacts/dev-result.json"],
+      agentHandles: { dev: "thread-or-agent-id" }
+    });
+
+    const result = runScript(PRE_COMPACT_HOOK_PATH, { cwd: tmpDir }, { cwd: tmpDir });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const payload = JSON.parse(result.stdout);
+    expect(payload.systemMessage).toContain("# Crew PreCompact Checkpoint");
+    expect(payload.systemMessage).toContain("Pending: qa verification");
+    expect(payload.systemMessage).toContain("- dev: thread-or-agent-id");
+  });
+});

--- a/tests/runner/crewState.test.mjs
+++ b/tests/runner/crewState.test.mjs
@@ -1,0 +1,76 @@
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  createCheckpoint,
+  getLatestCheckpoint,
+  readRunState,
+  writeRunState
+} from "../../lib/crew-state.mjs";
+import { cleanupTmpDir, mkTmpDir } from "../_helpers/fs.mjs";
+
+let tmpDir;
+
+afterEach(async () => {
+  if (tmpDir) {
+    await cleanupTmpDir(tmpDir);
+    tmpDir = undefined;
+  }
+});
+
+describe("crew run state", () => {
+  test("reads null when current run state does not exist", async () => {
+    tmpDir = await mkTmpDir();
+    expect(await readRunState(join(tmpDir, ".crew"))).toBeNull();
+  });
+
+  test("writes current run state atomically and returns a new object", async () => {
+    tmpDir = await mkTmpDir();
+    const crewDir = join(tmpDir, ".crew");
+    const state = {
+      active: true,
+      workflow: "crew-dev",
+      phase: "qa",
+      taskId: "TASK-123"
+    };
+
+    const written = await writeRunState(crewDir, state);
+
+    expect(written).not.toBe(state);
+    expect(written).toMatchObject({
+      version: 1,
+      active: true,
+      workflow: "crew-dev",
+      phase: "qa",
+      taskId: "TASK-123"
+    });
+    expect(written.lastUpdatedAt).toEqual(expect.any(String));
+    expect(state.lastUpdatedAt).toBeUndefined();
+    expect(await readRunState(crewDir)).toEqual(written);
+  });
+
+  test("creates and resolves latest checkpoint from current run state", async () => {
+    tmpDir = await mkTmpDir();
+    const crewDir = join(tmpDir, ".crew");
+    await mkdir(crewDir, { recursive: true });
+    await writeRunState(crewDir, {
+      active: true,
+      workflow: "crew-dev",
+      phase: "dev",
+      artifactPaths: [".crew/artifacts/dev-result.json"]
+    });
+
+    const checkpointPath = await createCheckpoint(crewDir);
+    const latest = await getLatestCheckpoint(crewDir);
+
+    expect(latest).toBe(checkpointPath);
+    expect(JSON.parse(await readFile(checkpointPath, "utf8"))).toMatchObject({
+      active: true,
+      workflow: "crew-dev",
+      phase: "dev",
+      artifactPaths: [".crew/artifacts/dev-result.json"]
+    });
+  });
+});

--- a/tests/runner/dispatch.test.mjs
+++ b/tests/runner/dispatch.test.mjs
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -9,6 +10,8 @@ import {
   dispatch,
   resolveAutoGitDiffInputs
 } from "../../scripts/lib/dispatch.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 let tmpDir;
 
@@ -47,15 +50,16 @@ async function writeRequest(request = requestFixture()) {
 function runDispatch(args, env = {}, options = {}) {
   return spawnSync(
     process.execPath,
-    [resolve("scripts/crew-agent-runner.mjs"), "dispatch", ...args],
+    [join(REPO_ROOT, "scripts", "crew-agent-runner.mjs"), "dispatch", ...args],
     {
       cwd: options.cwd ?? process.cwd(),
       encoding: "utf8",
       env: {
         ...process.env,
-        CREW_COMPANION_NODE_BIN: resolve("tests/_helpers/fakeCompanion.mjs"),
+        CREW_COMPANION_NODE_BIN: resolve(REPO_ROOT, "tests/_helpers/fakeCompanion.mjs"),
         ...env
-      }
+      },
+      ...options
     }
   );
 }
@@ -149,9 +153,7 @@ describe("crew-agent-runner dispatch CLI", () => {
     await writeFile(
       join(tmpDir, ".crew", "config.json"),
       JSON.stringify({
-        agent_defaults: {
-          qa: { provider: "claude", model: "sonnet" }
-        }
+        providers: { qa: { provider: "claude", model: "sonnet" } }
       }),
       "utf8"
     );

--- a/tests/runner/dispatch.test.mjs
+++ b/tests/runner/dispatch.test.mjs
@@ -47,6 +47,19 @@ async function writeRequest(request = requestFixture()) {
   return requestPath;
 }
 
+async function writeProjectConfig(config) {
+  await mkdir(join(tmpDir, ".crew"), { recursive: true });
+  await writeFile(join(tmpDir, ".crew", "config.json"), JSON.stringify(config), "utf8");
+}
+
+async function writeDevCodexProjectConfig() {
+  await writeProjectConfig({
+    providers: {
+      dev: { provider: "codex", model: "gpt-5.5", reasoning: "medium" }
+    }
+  });
+}
+
 function runDispatch(args, env = {}, options = {}) {
   return spawnSync(
     process.execPath,
@@ -95,11 +108,13 @@ describe("crew-agent-runner dispatch CLI", () => {
 
   test("runs companion with a prompt file and returns AgentResult with agent_handle", async () => {
     const requestPath = await writeRequest();
+    await writeDevCodexProjectConfig();
     const logPath = join(tmpDir, "fake-companion.log");
 
     const result = runDispatch(
       ["--role", "dev", "--request-file", requestPath, "--json", "--no-checkpoint"],
-      { FAKE_COMPANION_RESPONSE: "complete", FAKE_COMPANION_LOG: logPath }
+      { FAKE_COMPANION_RESPONSE: "complete", FAKE_COMPANION_LOG: logPath },
+      { cwd: tmpDir }
     );
 
     expect(result.status).toBe(0);
@@ -149,14 +164,9 @@ describe("crew-agent-runner dispatch CLI", () => {
 
   test("rejects claude provider roles with a dispatch-specific usage error", async () => {
     const requestPath = await writeRequest();
-    await mkdir(join(tmpDir, ".crew"), { recursive: true });
-    await writeFile(
-      join(tmpDir, ".crew", "config.json"),
-      JSON.stringify({
-        providers: { qa: { provider: "claude", model: "sonnet" } }
-      }),
-      "utf8"
-    );
+    await writeProjectConfig({
+      providers: { qa: { provider: "claude", model: "sonnet" } }
+    });
 
     const result = runDispatch(
       ["--role", "qa", "--request-file", requestPath, "--json"],
@@ -173,11 +183,13 @@ describe("crew-agent-runner dispatch CLI", () => {
 
   test("adds --write for workspace-write roles and preserves failed AgentResult on stdout", async () => {
     const requestPath = await writeRequest();
+    await writeDevCodexProjectConfig();
     const logPath = join(tmpDir, "fake-companion.log");
 
     const result = runDispatch(
       ["--role", "dev", "--request-file", requestPath, "--json"],
-      { FAKE_COMPANION_RESPONSE: "failed", FAKE_COMPANION_LOG: logPath }
+      { FAKE_COMPANION_RESPONSE: "failed", FAKE_COMPANION_LOG: logPath },
+      { cwd: tmpDir }
     );
 
     expect(result.status).toBe(1);
@@ -298,6 +310,7 @@ describe("crew-agent-runner dispatch CLI", () => {
 
   test("uses --resume-last only when resume candidate matches requested handle", async () => {
     const requestPath = await writeRequest();
+    await writeDevCodexProjectConfig();
     const logPath = join(tmpDir, "fake-companion.log");
 
     const result = runDispatch(
@@ -311,7 +324,8 @@ describe("crew-agent-runner dispatch CLI", () => {
         "--json",
         "--no-checkpoint"
       ],
-      { FAKE_COMPANION_RESPONSE: "resumeCandidate", FAKE_COMPANION_LOG: logPath }
+      { FAKE_COMPANION_RESPONSE: "resumeCandidate", FAKE_COMPANION_LOG: logPath },
+      { cwd: tmpDir }
     );
 
     expect(result.status).toBe(0);
@@ -324,6 +338,7 @@ describe("crew-agent-runner dispatch CLI", () => {
 
   test("rejects a resume handle that is not the companion candidate", async () => {
     const requestPath = await writeRequest();
+    await writeDevCodexProjectConfig();
 
     const result = runDispatch(
       [
@@ -335,7 +350,8 @@ describe("crew-agent-runner dispatch CLI", () => {
         "thread-other",
         "--json"
       ],
-      { FAKE_COMPANION_RESPONSE: "resumeCandidate" }
+      { FAKE_COMPANION_RESPONSE: "resumeCandidate" },
+      { cwd: tmpDir }
     );
 
     expect(result.status).toBe(1);
@@ -345,10 +361,12 @@ describe("crew-agent-runner dispatch CLI", () => {
 
   test("exits non-zero with a diagnostic for crewAgentResultError", async () => {
     const requestPath = await writeRequest();
+    await writeDevCodexProjectConfig();
 
     const result = runDispatch(
       ["--role", "dev", "--request-file", requestPath, "--json"],
-      { FAKE_COMPANION_RESPONSE: "crewAgentResultError" }
+      { FAKE_COMPANION_RESPONSE: "crewAgentResultError" },
+      { cwd: tmpDir }
     );
 
     expect(result.status).toBe(1);

--- a/tests/runner/prepare.test.mjs
+++ b/tests/runner/prepare.test.mjs
@@ -40,6 +40,11 @@ async function writeRequest() {
   return requestPath;
 }
 
+async function writeProjectConfig(config) {
+  await mkdir(join(tmpDir, ".crew"), { recursive: true });
+  await writeFile(join(tmpDir, ".crew", "config.json"), JSON.stringify(config), "utf8");
+}
+
 function runPrepare(args, options = {}) {
   return spawnSync(
     process.execPath,
@@ -51,14 +56,9 @@ function runPrepare(args, options = {}) {
 describe("crew-agent-runner prepare CLI", () => {
   test("returns an agent action with rendered prompt for Claude provider roles", async () => {
     const requestPath = await writeRequest();
-    await mkdir(join(tmpDir, ".crew"), { recursive: true });
-    await writeFile(
-      join(tmpDir, ".crew", "config.json"),
-      JSON.stringify({
-        providers: { "plan-evaluator": { provider: "claude", model: "sonnet" } }
-      }),
-      "utf8"
-    );
+    await writeProjectConfig({
+      providers: { "plan-evaluator": { provider: "claude", model: "sonnet" } }
+    });
 
     const result = runPrepare([
       "--role",
@@ -84,6 +84,11 @@ describe("crew-agent-runner prepare CLI", () => {
 
   test("returns a dispatch action for Codex provider roles", async () => {
     const requestPath = await writeRequest();
+    await writeProjectConfig({
+      providers: {
+        dev: { provider: "codex", model: "gpt-5.5", reasoning: "medium" }
+      }
+    });
 
     const result = runPrepare([
       "--role",
@@ -91,7 +96,7 @@ describe("crew-agent-runner prepare CLI", () => {
       "--request-file",
       requestPath,
       "--json"
-    ]);
+    ], { cwd: tmpDir });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
@@ -101,7 +106,7 @@ describe("crew-agent-runner prepare CLI", () => {
       action: "dispatch",
       command: [
         "node",
-        join(process.cwd(), "scripts", "crew-agent-runner.mjs"),
+        join(REPO_ROOT, "scripts", "crew-agent-runner.mjs"),
         "dispatch",
         "--role",
         "dev",
@@ -114,12 +119,17 @@ describe("crew-agent-runner prepare CLI", () => {
 
   test("prints the dispatch command in text mode", async () => {
     const requestPath = await writeRequest();
+    await writeProjectConfig({
+      providers: {
+        dev: { provider: "codex", model: "gpt-5.5", reasoning: "medium" }
+      }
+    });
 
-    const result = runPrepare(["--role", "dev", "--request-file", requestPath]);
+    const result = runPrepare(["--role", "dev", "--request-file", requestPath], { cwd: tmpDir });
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe(
-      `node ${join(process.cwd(), "scripts", "crew-agent-runner.mjs")} dispatch --role dev --request-file ${requestPath} --json\n`
+      `node ${join(REPO_ROOT, "scripts", "crew-agent-runner.mjs")} dispatch --role dev --request-file ${requestPath} --json\n`
     );
   });
 });

--- a/tests/runner/prepare.test.mjs
+++ b/tests/runner/prepare.test.mjs
@@ -1,10 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, test } from "vitest";
 
 import { cleanupTmpDir, mkTmpDir } from "../_helpers/fs.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 let tmpDir;
 
@@ -37,17 +40,25 @@ async function writeRequest() {
   return requestPath;
 }
 
-function runPrepare(args) {
+function runPrepare(args, options = {}) {
   return spawnSync(
     process.execPath,
-    ["scripts/crew-agent-runner.mjs", "prepare", ...args],
-    { encoding: "utf8" }
+    [join(REPO_ROOT, "scripts", "crew-agent-runner.mjs"), "prepare", ...args],
+    { encoding: "utf8", ...options }
   );
 }
 
 describe("crew-agent-runner prepare CLI", () => {
   test("returns an agent action with rendered prompt for Claude provider roles", async () => {
     const requestPath = await writeRequest();
+    await mkdir(join(tmpDir, ".crew"), { recursive: true });
+    await writeFile(
+      join(tmpDir, ".crew", "config.json"),
+      JSON.stringify({
+        providers: { "plan-evaluator": { provider: "claude", model: "sonnet" } }
+      }),
+      "utf8"
+    );
 
     const result = runPrepare([
       "--role",
@@ -55,7 +66,7 @@ describe("crew-agent-runner prepare CLI", () => {
       "--request-file",
       requestPath,
       "--json"
-    ]);
+    ], { cwd: tmpDir });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");

--- a/tests/runner/resolve.test.mjs
+++ b/tests/runner/resolve.test.mjs
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -11,6 +12,8 @@ import {
 } from "../../scripts/lib/config.mjs";
 import { resolveRole } from "../../scripts/lib/resolve.mjs";
 import { cleanupTmpDir, mkTmpDir } from "../_helpers/fs.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 let tmpDir;
 
@@ -138,11 +141,23 @@ describe("config loaders", () => {
 });
 
 describe("crew-agent-runner resolve CLI", () => {
-  test("prints JSON for planner role", () => {
+  test("prints JSON for planner role", async () => {
+    tmpDir = await mkTmpDir();
+    await mkdir(join(tmpDir, ".crew"), { recursive: true });
+    await writeFile(
+      join(tmpDir, ".crew", "config.json"),
+      JSON.stringify({
+        providers: {
+          planner: { provider: "codex", model: "gpt-5.5", reasoning: "medium" }
+        }
+      }),
+      "utf8"
+    );
+
     const result = spawnSync(
       process.execPath,
-      ["scripts/crew-agent-runner.mjs", "resolve", "--role", "planner", "--json"],
-      { encoding: "utf8" }
+      [join(REPO_ROOT, "scripts", "crew-agent-runner.mjs"), "resolve", "--role", "planner", "--json"],
+      { encoding: "utf8", cwd: tmpDir }
     );
 
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary

- crew run state 저장 helper 추가 (`lib/crew-state.mjs`) — `readRunState`, `writeRunState`, `createCheckpoint`, `getLatestCheckpoint`
- `PreCompact` hook 추가 — compact 직전 `.crew/state/checkpoints/`에 checkpoint 저장 + 복원용 `systemMessage` 반환
- `Stop` context guard 추가 — context 사용률 75-95% 구간에서 `/compact` 실행 유도 (context_limit/abort bypass, session별 2회 제한)
- `SessionStart` restore 추가 — 세션 시작 시 active run/checkpoint 감지하여 복원 context 주입
- CLI 테스트의 카탈로그 기본값 암묵적 의존 제거 — 모든 CLI 테스트에 project config override 패턴 적용

Closes #46

## Test plan

- [x] `tests/runner/crewState.test.mjs` — run state read/write/checkpoint helper 테스트 (3 tests)
- [x] `tests/hooks/contextCheckpoint.test.mjs` — PreCompact checkpoint, Stop guard block/bypass, SessionStart restore 테스트 (4 tests)
- [x] `tests/runner/prepare.test.mjs` — project config override 패턴 적용 확인 (3 tests)
- [x] `tests/runner/dispatch.test.mjs` — project config override 패턴 적용 확인 (9 tests)
- [x] `tests/runner/resolve.test.mjs` — project config override 패턴 적용 확인 (6 tests)
- [x] Full test suite: 23 files, 113 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)