### PR TITLE
fix: 워크트리에서 CLAUDE_PLUGIN_ROOT fallback으로 plugin root 해석

### DIFF
--- a/scripts/setup-hud.mjs
+++ b/scripts/setup-hud.mjs
@@ -11,6 +11,7 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
+import { PLUGIN_ROOT } from './lib/pluginRoot.mjs';
 
 // ---------------------------------------------------------------------------
 // Read stdin (with timeout)
@@ -31,6 +32,39 @@ function gitExec(cmd, cwd) {
   try {
     return execSync(cmd, { cwd, encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
   } catch { return null; }
+}
+
+function readPluginVersion() {
+  const packageJson = JSON.parse(readFileSync(join(PLUGIN_ROOT, 'package.json'), 'utf-8'));
+  return packageJson.version;
+}
+
+function updatePluginRootCache(pluginRoot) {
+  try {
+    const crewDir = join(homedir(), '.claude', 'crew');
+    const cachePath = join(crewDir, 'plugin-root.json');
+
+    let shouldWrite = !existsSync(cachePath);
+    if (!shouldWrite) {
+      try {
+        const current = JSON.parse(readFileSync(cachePath, 'utf-8'));
+        shouldWrite = current.pluginRoot !== pluginRoot;
+      } catch {
+        shouldWrite = true;
+      }
+    }
+
+    if (!shouldWrite) return;
+
+    mkdirSync(crewDir, { recursive: true });
+    writeFileSync(cachePath, JSON.stringify({
+      pluginRoot,
+      version: readPluginVersion(),
+      updatedAt: new Date().toISOString(),
+    }, null, 2));
+  } catch {
+    // Best-effort cache for runner fallback. HUD setup must continue on failure.
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +107,8 @@ async function main() {
       mkdirSync(join(projectRoot, '.claude'), { recursive: true });
       writeFileSync(localSettingsPath, JSON.stringify(localSettings, null, 2));
     }
+
+    updatePluginRootCache(pluginRoot);
 
     console.log(JSON.stringify({ continue: true }));
   } catch (e) {

--- a/skills/crew-agent-runner/SKILL.md
+++ b/skills/crew-agent-runner/SKILL.md
@@ -7,12 +7,25 @@ description: 모든 crew 에이전트 dispatch의 중앙 규약 — provider별 
 
 crew 업무 스킬은 에이전트 provider별 호출 세부사항을 직접 구현하지 않고 이 중앙 규약을 따른다. 본 스킬은 prepare, resolve, dispatch, resume, followup 주입, retry/fallback/escalate 판단의 공통 표면을 정의한다.
 
-설치 후 drift 차단용 pre-commit hook은 `node scripts/crew-agent-runner.mjs install-hooks`로 설치한다.
+설치 후 drift 차단용 pre-commit hook은 `node "$CREW_ROOT/scripts/crew-agent-runner.mjs" install-hooks`로 설치한다.
 (plugin 개발자 전용 — 사용자는 호출하지 않습니다. build/validate는 plugin source repo의 drift 차단 도구입니다.)
 
 ## Dispatch 절차
 
 업무 스킬(crew-plan/crew-interview/crew-dev)이 role을 실행해야 할 때 본 절차를 따른다.
+
+### Step 0. Runner 경로 결정
+
+오케스트레이터는 runner 호출 전에 plugin root를 결정하고, 결정된 경로를 `CREW_ROOT`로 사용한다.
+
+Fallback 체인 (순서 중요):
+
+1. `$CLAUDE_PLUGIN_ROOT`가 있으면 사용한다. 정상 Claude Code plugin 환경이므로 추가 검증하지 않는다.
+2. `~/.claude/crew/plugin-root.json`의 `pluginRoot`를 읽는다. 해당 경로에 `scripts/crew-agent-runner.mjs`가 존재하면 사용하고, 없으면 다음 fallback으로 진행한다.
+3. `git rev-parse --show-toplevel` 결과를 dev 환경 전용 후보로 사용한다. 해당 경로의 `package.json`에서 `name`이 `@jjlabsio/claude-crew`인지 검증하고, 맞으면 사용한다. 아니면 다음 fallback으로 진행한다.
+4. 모든 fallback이 실패하면 `'/crew-setup을 먼저 실행하세요'` 에러 메시지로 중단한다.
+
+이후 모든 runner 호출은 `node "$CREW_ROOT/scripts/crew-agent-runner.mjs"` 형식을 사용한다.
 
 ### 1. request 객체 작성
 
@@ -20,7 +33,7 @@ crew 업무 스킬은 에이전트 provider별 호출 세부사항을 직접 구
 
 ### 2. prepare
 
-오케스트레이터는 `node "$CLAUDE_PLUGIN_ROOT/scripts/crew-agent-runner.mjs" prepare --role <role> --request-file <request-file> --json`을 실행한다.
+오케스트레이터는 `node "$CREW_ROOT/scripts/crew-agent-runner.mjs" prepare --role <role> --request-file <request-file> --json`을 실행한다.
 prepare는 provider/model/contract를 해석하고 다음 action 중 하나를 반환한다.
 
 ### 3a. dispatch action
@@ -67,8 +80,8 @@ capability를 넘어선 도구 요청이다. 오케스트레이터가 `contract.
 
 ### Codex 경로
 
-1. `node scripts/crew-agent-runner.mjs render-followup --previous-result <file> --new-input <file>` 실행 → followup prompt 문자열 → 임시 파일에 저장.
-2. `node scripts/crew-agent-runner.mjs dispatch --role <role> --request-file <new-request-with-followup-prompt> --resume-handle <agent_handle> --json` 실행.
+1. `node "$CREW_ROOT/scripts/crew-agent-runner.mjs" render-followup --previous-result <file> --new-input <file>` 실행 → followup prompt 문자열 → 임시 파일에 저장.
+2. `node "$CREW_ROOT/scripts/crew-agent-runner.mjs" dispatch --role <role> --request-file <new-request-with-followup-prompt> --resume-handle <agent_handle> --json` 실행.
    - 내부적으로 runner가 `crew-codex-companion.mjs task-resume-candidate`로 thread 일치 검증 후 `task --resume-last`를 호출하고 AgentResult를 정규화한다.
 3. AgentResult JSON을 받아 다음 상태 처리.
 

--- a/skills/crew-setup/SKILL.md
+++ b/skills/crew-setup/SKILL.md
@@ -102,6 +102,27 @@ push는 하지 않는다.
 
 ---
 
+## Step 2b — Plugin Root 영속화
+
+`$CLAUDE_PLUGIN_ROOT`가 살아있는 setup 시점에 runner fallback용 plugin root를 사용자 데이터 영역에 저장한다.
+
+1. `~/.claude/crew/` 디렉토리가 없으면 생성한다.
+2. `~/.claude/crew/plugin-root.json`을 다음 형식으로 쓴다. 기존 파일이 있으면 덮어쓴다.
+   ```json
+   {
+     "pluginRoot": "<$CLAUDE_PLUGIN_ROOT 값>",
+     "version": "<현재 플러그인 버전>",
+     "updatedAt": "<ISO timestamp>"
+   }
+   ```
+3. plugin 자체 데이터인 version은 plugin root 기준 `package.json`에서 읽는다.
+
+**주의**:
+- plugin root는 `$CLAUDE_PLUGIN_ROOT` 값을 사용한다.
+- `~/.claude/crew/plugin-root.json`은 사용자 데이터이므로 home 기준 경로에 저장한다.
+
+---
+
 ## Step 3 — Provider 설정
 
 에이전트별로 어떤 provider(claude/codex)와 model을 사용할지 설정한다.


### PR DESCRIPTION
## Summary
- 워크트리(EnterWorktree) 안에서 `$CLAUDE_PLUGIN_ROOT` 환경변수가 비어있어 `crew-agent-runner.mjs` 경로 해석이 실패하는 문제 수정
- `crew-agent-runner` SKILL.md에 Step 0 Runner 경로 결정 단계 추가 (fallback 체인: `$CLAUDE_PLUGIN_ROOT` → `plugin-root.json` → `git rev-parse` with 검증)
- `crew-setup` SKILL.md에 Step 2b plugin-root.json 영속화 단계 추가
- `setup-hud.mjs`에서 세션 시작 시 `~/.claude/crew/plugin-root.json` idempotent 갱신

## Test plan
- [ ] 사용 환경에서 `/crew-setup` 실행 후 `~/.claude/crew/plugin-root.json` 생성 확인
- [ ] 워크트리 진입 후 `/crew-do` 실행 시 `CREW_ROOT` fallback으로 runner 정상 호출 확인
- [ ] dev 환경(소스 리포) 워크트리에서 `git rev-parse` fallback 동작 확인
- [ ] 기존 테스트 통과 확인 (`prepare.test.mjs` 실패는 기존 main 이슈)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)